### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence.
 # By convention in @tablelandnetwork repos, the first listed
 # CODEOWNER is the repo DRI (directly responsible individual)
-*           @dtbuchholz
+*           @dtbuchholz @carsonfarmer @brunocalza


### PR DESCRIPTION
We need more than one CODEOWNER, otherwise we can't get things merged without that one person's signoff.