### PR TITLE
feat: use real txn hash for example

### DIFF
--- a/specs/validator/README.md
+++ b/specs/validator/README.md
@@ -162,8 +162,8 @@ Parameters
 ``` json
 {
   "table_id": "1",
-  "transaction_hash": "0x400508d7cc035b14cc53f64393a8dafcc55f66ad8f9b44d626744157337e2098",
-  "block_number": 1,
+  "transaction_hash": "0x02f319429b8a7be1cbb492f0bfbf740d2472232a2edadde7df7c16c0b61aa78b",
+  "block_number": 27055540,
   "chain_id": 80001,
   "error": "The query statement is invalid",
   "error_event_idx": 1
@@ -445,8 +445,8 @@ TransactionReceipt
 ``` json
 {
   "table_id": "1",
-  "transaction_hash": "0x400508d7cc035b14cc53f64393a8dafcc55f66ad8f9b44d626744157337e2098",
-  "block_number": 1,
+  "transaction_hash": "0x02f319429b8a7be1cbb492f0bfbf740d2472232a2edadde7df7c16c0b61aa78b",
+  "block_number": 27055540,
   "chain_id": 80001,
   "error": "The query statement is invalid",
   "error_event_idx": 1

--- a/specs/validator/Specification.md
+++ b/specs/validator/Specification.md
@@ -129,8 +129,8 @@ Returns the status of a given transaction receipt by hash
 ```json
 {
   "table_id": "1",
-  "transaction_hash": "0x400508d7cc035b14cc53f64393a8dafcc55f66ad8f9b44d626744157337e2098",
-  "block_number": 1,
+  "transaction_hash": "0x02f319429b8a7be1cbb492f0bfbf740d2472232a2edadde7df7c16c0b61aa78b",
+  "block_number": 27055540,
   "chain_id": 80001,
   "error": "The query statement is invalid",
   "error_event_idx": 1
@@ -400,8 +400,8 @@ continued
 ```json
 {
   "table_id": "1",
-  "transaction_hash": "0x400508d7cc035b14cc53f64393a8dafcc55f66ad8f9b44d626744157337e2098",
-  "block_number": 1,
+  "transaction_hash": "0x02f319429b8a7be1cbb492f0bfbf740d2472232a2edadde7df7c16c0b61aa78b",
+  "block_number": 27055540,
   "chain_id": 80001,
   "error": "The query statement is invalid",
   "error_event_idx": 1

--- a/specs/validator/tableland-openapi-spec.yaml
+++ b/specs/validator/tableland-openapi-spec.yaml
@@ -144,7 +144,7 @@ paths:
           required: true
           schema:
             type: string
-          example: "0x400508d7cc035b14cc53f64393a8dafcc55f66ad8f9b44d626744157337e2098"
+          example: "0x02f319429b8a7be1cbb492f0bfbf740d2472232a2edadde7df7c16c0b61aa78b"
       responses:
         "200":
           description: successful operation
@@ -250,11 +250,11 @@ components:
           example: "1"
         transaction_hash:
           type: string
-          example: "0x400508d7cc035b14cc53f64393a8dafcc55f66ad8f9b44d626744157337e2098"
+          example: "0x02f319429b8a7be1cbb492f0bfbf740d2472232a2edadde7df7c16c0b61aa78b"
         block_number:
           type: integer
           format: int64
-          example: 1
+          example: 27055540
         chain_id:
           type: integer
           format: int32


### PR DESCRIPTION
This change means that all examples and placeholder values are also valid queries on maticmum. So users can play around with the APIs without having to know anything about where to get txn hahes, table ids, etc