### PR TITLE
s6c3a docs updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/config/metadata.js
+++ b/config/metadata.js
@@ -7,7 +7,7 @@ const metadata = [
   {
     name: "og:title",
     content:
-      "Tableland Docs: API reference, quickstart guides, and protocol integrations",
+      "Tableland Docs: Store & query data using the serverless database for web3 apps.",
   },
   {
     name: "twitter:title",
@@ -25,7 +25,7 @@ const metadata = [
   {
     name: "keywords",
     content:
-      "tableland, docs, documentation, web3, crypto, blockchain, SQL, SQLite, relational, database",
+      "tableland, docs, documentation, web3, crypto, blockchain, SQL, SQLite, relational, database, serverless, permissionless, evm, decentralized",
   },
 ];
 

--- a/config/metadata.js
+++ b/config/metadata.js
@@ -2,21 +2,21 @@ const metadata = [
   {
     name: "description",
     content:
-      "The official documentation for the Tableland Network. Build web3 with SQL using smart contracts, SDKs, and APIs, and learn all about the protocol.",
+      "The official documentation for Tableland. Read & write tamperproof data from apps, data pipelines, or EVM smart contracts.",
   },
   {
     name: "og:title",
     content:
-      "Tableland Docs: Store & query data using the serverless database for web3 apps.",
+      "Tableland Docs: Read & write tamperproof data using the decentralized cloud database for web3 apps.",
   },
   {
     name: "twitter:title",
-    content: "Tableland Docs",
+    content: "Tableland: Permissionless cloud database", // Need to fit within Twitter card title char limit
   },
   {
     name: "twitter:description",
     content:
-      "The official documentation for the Tableland Network. Build web3 with SQL.",
+      "Read & write tamperproof data from apps, data pipelines, or EVM smart contracts.",
   },
   {
     name: "og:site_name",
@@ -25,7 +25,7 @@ const metadata = [
   {
     name: "keywords",
     content:
-      "tableland, docs, documentation, web3, crypto, blockchain, SQL, SQLite, relational, database, serverless, permissionless, evm, decentralized",
+      "tableland, table land, docs, documentation, web3, crypto, blockchain, SQL, SQLite, relational, database, serverless, permissionless, evm, decentralized, data pipeline, open source",
   },
 ];
 

--- a/docs/fundamentals/about/open-beta.md
+++ b/docs/fundamentals/about/open-beta.md
@@ -44,7 +44,7 @@ During the open beta phase (between now and the production release), projects de
   - We will make our best effort to auto-redirect queries to the right chain, but just to be certain, please make sure `baseURI` is updatable.
   - In particular, NFT smart contracts should be able to update their `baseURI`, `tokenURI`, or any other method that references the the `testnets` gateway on a mainnet contract.
 - Another option is to future-proof your smart contracts to make sure [upgradeability patterns](https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable) are possible. This is not required but a potentially useful pattern to implement.
-- Note—Since this is a future endeavor, documentation on how to make these changes in your project does not exist yet but will be shared closer to the migration date. In the meantime, check out OpenZeppelin’s `[Ownable](https://docs.openzeppelin.com/contracts/2.x/api/ownership#Ownable)` (e.g., an `onlyOwner` modifier for altering a `baseURI`) and [upgradable contracts](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable).
+- Note—since this is a future endeavor, documentation on how to make these changes in your project does not exist yet but will be shared closer to the migration date. In the meantime, check out OpenZeppelin’s [`Ownable`](https://docs.openzeppelin.com/contracts/2.x/api/ownership#Ownable) (e.g., an `onlyOwner` modifier for altering a `baseURI`) and [upgradable contracts](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable).
 
 ### Are there costs involved?
 

--- a/docs/fundamentals/architecture/limits.md
+++ b/docs/fundamentals/architecture/limits.md
@@ -55,12 +55,13 @@ You can create tables and write data to it within the same on-chain transaction,
 
 When a table is created or written to, there will be a "lag" between calling the smart contract and the time at which the event’s SQL instructions are materialized in Tableland. This "lag" is documented below as **a chain-driven limitation** due to block times.
 
-| Chain    | Average block finalization time |
-| -------- | ------------------------------- |
-| Ethereum | 13.5 seconds                    |
-| Optimism | 2 seconds                       |
-| Arbitrum | <0.5 seconds                    |
-| Polygon  | 2 seconds                       |
+| Chain         | Average block finalization time |
+| ------------- | ------------------------------- |
+| Ethereum      | 13.5 seconds                    |
+| Optimism      | 2 seconds                       |
+| Arbitrum One  | <0.5 seconds                    |
+| Arbitrum Nova | 2-3 seconds                     |
+| Polygon       | 2 seconds                       |
 
 ### Table reads
 

--- a/docs/smart-contracts/using-sql-helpers.md
+++ b/docs/smart-contracts/using-sql-helpers.md
@@ -5,7 +5,7 @@ description: Use the SQL helpers library to make it easier write SQL in Solidity
 
 When creating and writing to tables, Solidity can be a bit challenging to work with when it comes to forming SQL statements. The `SQLHelpers` library provides a series of helper methods to ease writing create table statements, insert, updates, and deletes, and it also has a couple of common helpers. This page describes these methods, their function signatures, and links to the actual implementation.
 
-## [`toNameFromSchema`](https://github.com/tablelandnetwork/evm-tableland/blob/b350a363ea3d10bbeb3d3a088e9c27c77c6cae30/contracts/utils/SQLHelpers.sol#L20)
+## [`toNameFromId`](https://github.com/tablelandnetwork/evm-tableland/blob/b350a363ea3d10bbeb3d3a088e9c27c77c6cae30/contracts/utils/SQLHelpers.sol#L20)
 
 Pass a table `prefix` and `tableId`, which returns the formatted table name as `{prefix}_{chainId}_{tableId}` (e.g., `healthbot_1_1`).
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -145,7 +145,7 @@ const config = {
           dark: "dark",
         },
         options: {
-          fontFamily: "Inter",
+          fontFamily: "Poppins",
         },
       },
       // Announcement bar is upon visiting the site and removed if the user closes it out (tracked in local storage)

--- a/src/components/Home/index.module.css
+++ b/src/components/Home/index.module.css
@@ -17,3 +17,19 @@
   content: "→";
   padding-left: 0.2rem;
 }
+
+@media (max-width: 996px) {
+  .landingImage {
+    margin-top: 60px;
+    margin-bottom: 0;
+  }
+  .containerMain {
+    margin-top: 0;
+  }
+}
+
+@media (max-width: 640px) {
+  .landingImage {
+    width: 80vw;
+  }
+}

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -10,7 +10,7 @@ export default function Home(): JSX.Element {
   const { siteConfig } = useDocusaurusContext();
   return (
     <>
-      <header className="landing-page margin-top--lg">
+      <header className="landing-page margin-top--md">
         <div className="container">
           <div className="row">
             <h1 className="hero__title">Documentation</h1>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -96,7 +96,7 @@
   --ifm-toc-border-color: var(--color-green) !important;
   --ifm-menu-color: var(--color-neonblue) !important;
   --ifm-card-background-color: var(--color-green) !important;
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.4);
   /* Make the navbar the same color as the background; include bottom box */
   --ifm-color-content-secondary: rgba(255, 255, 255, 1);
   --ifm-toc-link-color: var(--ifm-menu-color);

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -11,6 +11,8 @@
 :root {
   /* Colors (light mode colors are the default) */
   --color-black: #1a1a1a;
+  --color-blue: #6067eb;
+  --color-darkblue: #141034;
   --color-neonblue: #75b6b5;
   --color-grey: #5d657f;
   --color-orange: #f4706b;
@@ -306,12 +308,12 @@ a:hover {
 }
 
 html[data-theme="dark"] .alert--secondary {
- background-color: var(--color-black);
+  background-color: var(--color-black);
 }
 
 html[data-theme="dark"] .alert--success {
   background-color: var(--color-lightgreen);
-  border-left-color: var(--color-neongreen); 
+  border-left-color: var(--color-neongreen);
 }
 
 /* Don't darken the heading's `#` anchor tag on hover */
@@ -406,7 +408,7 @@ html[data-theme="dark"] .button {
 }
 
 .menu__link--active {
-  font-weight: var(--ifm-font-weight-semibold);
+  font-weight: var(--ifm-font-weight-bold);
 }
 
 .menu__link:not(.menu__link--active) {
@@ -433,6 +435,12 @@ spacing. */
   .menu__list-item:nth-child(3) {
   padding-top: 0;
   margin-top: 0;
+}
+
+/* Make table of contents active link/section a different color in dark mode */
+html[data-theme="dark"]
+  .table-of-contents__link:not(.table-of-contents__link--active) {
+  color: var(--color-verylightgreen);
 }
 
 /* Pagination fixes background color, do not change font color on hover, and change icons */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -294,11 +294,6 @@ a {
   transition: color var(--ifm-transition-fast);
 }
 
-/* Darken color on link hover; lighten on dark mode */
-a:hover {
-  text-decoration: underline;
-}
-
 /* In tooltips, highlight anchors are embedded links and change opacity on hover */
 .alert a {
   text-decoration: underline;
@@ -306,7 +301,7 @@ a:hover {
 }
 
 .alert a:hover {
-  text-decoration: underline;
+  text-decoration-thickness: inherit;
   opacity: 0.7;
   transition: opacity var(--ifm-transition-fast);
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -20,6 +20,7 @@
   --color-green: #162929;
   --color-darkgreen: #101e1e;
   --color-lightgreen: #3b4949;
+  --color-verylightgreen-rgb: 113, 139, 139;
   --color-verylightgreen: #718b8b;
   --color-neongreen: #0be291;
 
@@ -96,7 +97,10 @@
   --ifm-toc-border-color: var(--color-green) !important;
   --ifm-menu-color: var(--color-neonblue) !important;
   --ifm-card-background-color: var(--color-green) !important;
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.4);
+  --docusaurus-highlighted-code-line-bg: rgba(
+    var(--color-verylightgreen-rgb),
+    0.2
+  );
   /* Make the navbar the same color as the background; include bottom box */
   --ifm-color-content-secondary: rgba(255, 255, 255, 1);
   --ifm-toc-link-color: var(--ifm-menu-color);


### PR DESCRIPTION
## Summary
Some small tweaks to the site:
- Add dependabot to the repo (note: are monthly updates the right frequency?).
- Made some tweaks to the site's metadata (note: not an SEO guru by any means).
- Content adjusted wrt touching multiple tables in single tx, fix for a misformatted markdown link, add Nova to limits, and some verbiage changes.
- Update mermaid diagram font to Poppins (used to be inter but not rendering after default font change to Poppins).
- Minor style changes:
  - Make the active section (dark mode) in the right side's table of contents (via scrolling) more prominent by changing the color of inactive sections to a different color / very light green (matches the light mode's general design).
  - Heavy bold the active page in the left sidebar (previously, semi-bolded) to also make it more prominent. (Alternatively, could do something like the table of contents above where non-active sidebar pages are very light green.)
  - Dark mode code snippet highlighting—it was too dark before and blended it w/ the bg.
  - Landing page's top margin reduced to make it more vertically centered, and the landing image size/top margin also altered on small screens (was too small / close to the "Get started" btn).