### PR TITLE
[DOC-14] Add shell documentation

### DIFF
--- a/config/sidebars.js
+++ b/config/sidebars.js
@@ -322,7 +322,7 @@ const sidebars = {
     {
       type: "doc",
       id: "cli/README",
-      label: "Command Line",
+      label: "CLI",
       className: "sidebar-landing",
     },
     {

--- a/config/sidebars.js
+++ b/config/sidebars.js
@@ -238,7 +238,9 @@ const cli = [
   ...sidepageHeader("CLI"),
   ,
   "cli/README",
+  ...section("Commands"),
   "cli/commands",
+  ...section("Errors"),
   "cli/errors",
 ];
 
@@ -320,7 +322,7 @@ const sidebars = {
     {
       type: "doc",
       id: "cli/README",
-      label: "CLI",
+      label: "Command Line",
       className: "sidebar-landing",
     },
     {

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -828,7 +828,7 @@ You can use a multi-line query. The shell will check for a semi-colon to know wh
 ```bash
 tableland>select 
 tableland>    id, name
-tableland->   FROM
+tableland>   FROM
 tableland>    cli_demo_table_31337_2;
 {
   meta: { duration: 18.574082374572754 },

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -822,3 +822,44 @@ Which will print:
   }
 }
 ```
+
+You can use a multi-line query. The shell will check for a semi-colon to know when you're done.
+
+```bash
+tableland>select 
+tableland>    id, name
+tableland->   FROM
+tableland>    cli_demo_table_31337_2;
+{
+  meta: { duration: 18.574082374572754 },
+  success: true,
+  results: [ { id: 1, name: 'Bobby Tables' } ]
+}
+{
+  response: {
+    meta: { duration: 18.574082374572754 },
+    success: true,
+    results: [ { id: 1, name: 'Bobby Tables' } ]
+  }
+}
+```
+
+With write statements, (`create`, `update`, and `delete` statements) you'll need to confirm the write.
+Your flow would look like this: 
+
+```bash
+tableland shell
+tableland>insert into cli_demo_table_31337_2;
+You are sending a transaction to the network, using gas. Are you sure? (y/n) y
+[]
+{"updatedTable":"cli_demo_table_31337_2"}
+```
+
+There are also a couple of functions in the shell you can call. 
+
+Namely, `.help` and `.exit`.
+
+`.help` me give you help on how to use the command.
+
+`.exit` will close the shell.
+

--- a/docs/cli/shell.md
+++ b/docs/cli/shell.md
@@ -1,0 +1,11 @@
+---
+title: CLI Shell command
+sidebar_label: Commands
+description: The Tableland CLI comes with purpose built commands, which slightly differs from the convention in other clients.
+keywords:
+  - cli
+  - command line
+  - shell
+---
+
+


### PR DESCRIPTION
We needed a little bit more in the docs for the shell command. Here it is. 

This PR also changes the name in the sidebar from "CLI" to "Command Line"