### PR TITLE
Fixes the receipt schema to return an array of table ids

### DIFF
--- a/docs/gateway-api/endpoints.md
+++ b/docs/gateway-api/endpoints.md
@@ -164,10 +164,10 @@ Example responses
 
 ```json
 {
-  "name": "healthbot_5_1",
-  "external_url": "https://testnets.tableland.network/api/v1/tables/healthbot_5_1",
-  "animation_url": "https://render.tableland.xyz/anim/?chain=1&id=1",
-  "image": "https://render.tableland.xyz/healthbot_5_1",
+  "name": "healthbot_80001_1",
+  "external_url": "https://testnets.tableland.network/api/v1/tables/80001/1",
+  "animation_url": "https://tables.testnets.tableland.xyz/80001/1.html",
+  "image": "https://tables.testnets.tableland.xyz/80001/1.svg",
   "attributes": {
     "display_type": "date",
     "trait_type": "created",
@@ -267,10 +267,10 @@ This operation does not require authentication
 
 ```json
 {
-  "name": "healthbot_5_1",
-  "external_url": "https://testnets.tableland.network/api/v1/tables/healthbot_5_1",
-  "animation_url": "https://render.tableland.xyz/anim/?chain=1&id=1",
-  "image": "https://render.tableland.xyz/healthbot_5_1",
+  "name": "healthbot_80001_1",
+  "external_url": "https://testnets.tableland.network/api/v1/tables/80001/1",
+  "animation_url": "https://tables.testnets.tableland.xyz/80001/1.html",
+  "image": "https://tables.testnets.tableland.xyz/80001/1.svg",
   "attributes": {
     "display_type": "date",
     "trait_type": "created",

--- a/docs/gateway-api/endpoints.md
+++ b/docs/gateway-api/endpoints.md
@@ -110,6 +110,10 @@ Example responses
 ```json
 {
   "table_id": "1",
+  "table_ids": [
+    "1",
+    "2"
+  ],
   "transaction_hash": "0x02f319429b8a7be1cbb492f0bfbf740d2472232a2edadde7df7c16c0b61aa78b",
   "block_number": 27055540,
   "chain_id": 80001,
@@ -339,6 +343,10 @@ This operation does not require authentication
 ```json
 {
   "table_id": "1",
+  "table_ids": [
+    "1",
+    "2"
+  ],
   "transaction_hash": "0x02f319429b8a7be1cbb492f0bfbf740d2472232a2edadde7df7c16c0b61aa78b",
   "block_number": 27055540,
   "chain_id": 80001,
@@ -349,14 +357,15 @@ This operation does not require authentication
 
 #### Properties
 
-| Name             | Type           | Required | Restrictions | Description |
-| ---------------- | -------------- | -------- | ------------ | ----------- |
-| table_id         | string         | false    | none         | none        |
-| transaction_hash | string         | false    | none         | none        |
-| block_number     | integer(int64) | false    | none         | none        |
-| chain_id         | integer(int32) | false    | none         | none        |
-| error            | string         | false    | none         | none        |
-| error_event_idx  | integer(int32) | false    | none         | none        |
+| Name             | Type           | Required | Restrictions | Description              |
+|------------------|----------------|----------|--------------|--------------------------|
+| table_id         | string         | false    | none         | This field is deprecated |
+| table_ids        | \[string\]     | false    | none         | none                     |
+| transaction_hash | string         | false    | none         | none                     |
+| block_number     | integer(int64) | false    | none         | none                     |
+| chain_id         | integer(int32) | false    | none         | none                     |
+| error            | string         | false    | none         | none                     |
+| error_event_idx  | integer(int32) | false    | none         | none                     |
 
 ### Schema
 

--- a/docs/quickstarts/api-quickstart.md
+++ b/docs/quickstarts/api-quickstart.md
@@ -81,14 +81,14 @@ curl -X GET https://testnets.tableland.network/api/v1/tables/80001/1 \
   -H 'Accept: application/json'
 ```
 
-The response includes information like the table's schema, the table's data shown in the [Console](https://console.tableland.xyz/) (at the [`animation_url`](https://testnets.render.tableland.xyz/anim/?chain=80001&id=1)), date created, etc.
+The response includes information like the table's schema, the table's data shown in the [Console](https://console.tableland.xyz/) (at the [`animation_url`](https://tables.testnets.tableland.xyz/80001/1.html)), date created, etc.
 
 ```json
 {
   "name": "healthbot_80001_1",
-  "external_url": "https://testnets.tableland.network/chain/80001/tables/1",
-  "animation_url": "https://testnets.render.tableland.xyz/anim/?chain=80001&id=1",
-  "image": "https://testnets.render.tableland.xyz/80001/1",
+  "external_url": "https://testnets.tableland.network/api/v1/tables/80001/1",
+  "animation_url": "https://tables.testnets.tableland.xyz/80001/1.html",
+  "image": "https://tables.testnets.tableland.xyz/80001/1.svg",
   "attributes": [
     {
       "display_type": "date",

--- a/docs/quickstarts/api-quickstart.md
+++ b/docs/quickstarts/api-quickstart.md
@@ -64,7 +64,9 @@ It [returns on-chain transaction information](https://testnets.tableland.network
 
 ```json
 {
-  "table_id": "1",
+  "table_ids": [
+    "1"
+  ],
   "transaction_hash": "0x02f319429b8a7be1cbb492f0bfbf740d2472232a2edadde7df7c16c0b61aa78b",
   "block_number": 27055540,
   "chain_id": 80001

--- a/specs/validator/README.md
+++ b/specs/validator/README.md
@@ -227,10 +227,10 @@ Parameters
 
 ``` json
 {
-  "name": "healthbot_5_1",
-  "external_url": "https://testnets.tableland.network/api/v1/tables/healthbot_5_1",
-  "animation_url": "https://tables.tableland.xyz/1/1.html",
-  "image": "https://tables.tableland.xyz/healthbot_5_1",
+  "name": "healthbot_80001_1",
+  "external_url": "https://testnets.tableland.network/api/v1/tables/80001/1",
+  "animation_url": "https://tables.testnets.tableland.xyz/80001/1.html",
+  "image": "https://tables.testnets.tableland.xyz/healthbot_80001_1",
   "attributes": {
     "display_type": "date",
     "trait_type": "created",
@@ -360,10 +360,10 @@ Table
 
 ``` json
 {
-  "name": "healthbot_5_1",
-  "external_url": "https://testnets.tableland.network/api/v1/tables/healthbot_5_1",
-  "animation_url": "https://tables.tableland.xyz/1/1.html",
-  "image": "https://tables.tableland.xyz/healthbot_5_1",
+  "name": "healthbot_80001_1",
+  "external_url": "https://testnets.tableland.network/api/v1/tables/80001/1",
+  "animation_url": "https://tables.testnets.tableland.xyz/80001/1.html",
+  "image": "https://tables.testnets.tableland.xyz/healthbot_80001_1",
   "attributes": {
     "display_type": "date",
     "trait_type": "created",

--- a/specs/validator/README.md
+++ b/specs/validator/README.md
@@ -10,16 +10,16 @@ This general API specification is used to automatically generate clients and bac
 
 ### Table of Contents
 
--   [Query the network](#query-the-network)
--   [Get transaction status](#get-transaction-status)
--   [Get table information](#get-table-information)
--   [Get health status](#get-health-status)
--   [Get version information](#get-version-information)
--   [Schemas](#schemas)
+- [Query the network](#query-the-network)
+- [Get transaction status](#get-transaction-status)
+- [Get table information](#get-table-information)
+- [Get health status](#get-health-status)
+- [Get version information](#get-version-information)
+- [Schemas](#schemas)
 
 <!-- Generator: Widdershins v4.0.1 -->
 <h1 id="tableland-validator-openapi-3-0">
-Tableland Validator - OpenAPI 3.0 v1.0.0
+Tableland Validator - OpenAPI 3.0 v1.0.1
 </h1>
 
 > Scroll down for code samples, example requests and responses. Select a
@@ -30,7 +30,7 @@ In Tableland, Validators are the execution unit/actors of the protocol.
 They have the following responsibilities: - Listen to on-chain events to
 materialize Tableland-compliant SQL queries in a database engine
 (currently, SQLite by default). - Serve read-queries (e.g: SELECT \*
-FROM foo\_69\_1) to the external world. - Serve state queries (e.g. list
+FROM foo_69_1) to the external world. - Serve state queries (e.g. list
 tables, get receipts, etc) to the external world.
 
 In the 1.0.0 release of the Tableland Validator API, we’ve switched to a
@@ -41,9 +41,9 @@ features in OAS3.
 
 Base URLs:
 
--   <a href="https://testnets.tableland.network/api/v1">https://testnets.tableland.network/api/v1</a>
+- <a href="https://testnets.tableland.network/api/v1">https://testnets.tableland.network/api/v1</a>
 
--   <a href="http://localhost:8080/api/v1">http://localhost:8080/api/v1</a>
+- <a href="http://localhost:8080/api/v1">http://localhost:8080/api/v1</a>
 
 <a href="http://docs.tableland.xyz">Terms of service</a> Email:
 <a href="mailto:carson@textile.io">core devs</a> License:
@@ -162,6 +162,10 @@ Parameters
 ``` json
 {
   "table_id": "1",
+  "table_ids": [
+    "1",
+    "2"
+  ],
   "transaction_hash": "0x02f319429b8a7be1cbb492f0bfbf740d2472232a2edadde7df7c16c0b61aa78b",
   "block_number": 27055540,
   "chain_id": 80001,
@@ -224,9 +228,9 @@ Parameters
 ``` json
 {
   "name": "healthbot_5_1",
-  "external_url": "https://testnet.tableland.network/tables/healthbot_5_1",
-  "animation_url": "https://render.tableland.xyz/anim/?chain=1&id=1",
-  "image": "https://render.tableland.xyz/healthbot_5_1",
+  "external_url": "https://testnets.tableland.network/api/v1/tables/healthbot_5_1",
+  "animation_url": "https://tables.tableland.xyz/1/1.html",
+  "image": "https://tables.tableland.xyz/healthbot_5_1",
   "attributes": {
     "display_type": "date",
     "trait_type": "created",
@@ -357,9 +361,9 @@ Table
 ``` json
 {
   "name": "healthbot_5_1",
-  "external_url": "https://testnet.tableland.network/tables/healthbot_5_1",
-  "animation_url": "https://render.tableland.xyz/anim/?chain=1&id=1",
-  "image": "https://render.tableland.xyz/healthbot_5_1",
+  "external_url": "https://testnets.tableland.network/api/v1/tables/healthbot_5_1",
+  "animation_url": "https://tables.tableland.xyz/1/1.html",
+  "image": "https://tables.tableland.xyz/healthbot_5_1",
   "attributes": {
     "display_type": "date",
     "trait_type": "created",
@@ -386,16 +390,16 @@ Table
 
 ### Properties
 
-| Name            | Type       | Required | Restrictions | Description                       |
-|-----------------|------------|----------|--------------|-----------------------------------|
-| name            | string     | false    | none         | none                              |
-| external\_url   | string     | false    | none         | none                              |
-| animation\_url  | string     | false    | none         | none                              |
-| image           | string     | false    | none         | none                              |
-| attributes      | \[object\] | false    | none         | none                              |
-| » display\_type | string     | false    | none         | The display type for marketplaces |
-| » trait\_type   | string     | false    | none         | The trait type for marketplaces   |
-| » value         | object     | false    | none         | The value of the property         |
+| Name           | Type       | Required | Restrictions | Description                       |
+|----------------|------------|----------|--------------|-----------------------------------|
+| name           | string     | false    | none         | none                              |
+| external_url   | string     | false    | none         | none                              |
+| animation_url  | string     | false    | none         | none                              |
+| image          | string     | false    | none         | none                              |
+| attributes     | \[object\] | false    | none         | none                              |
+| » display_type | string     | false    | none         | The display type for marketplaces |
+| » trait_type   | string     | false    | none         | The trait type for marketplaces   |
+| » value        | object     | false    | none         | The value of the property         |
 
 oneOf
 
@@ -445,6 +449,10 @@ TransactionReceipt
 ``` json
 {
   "table_id": "1",
+  "table_ids": [
+    "1",
+    "2"
+  ],
   "transaction_hash": "0x02f319429b8a7be1cbb492f0bfbf740d2472232a2edadde7df7c16c0b61aa78b",
   "block_number": 27055540,
   "chain_id": 80001,
@@ -455,14 +463,15 @@ TransactionReceipt
 
 ### Properties
 
-| Name              | Type           | Required | Restrictions | Description |
-|-------------------|----------------|----------|--------------|-------------|
-| table\_id         | string         | false    | none         | none        |
-| transaction\_hash | string         | false    | none         | none        |
-| block\_number     | integer(int64) | false    | none         | none        |
-| chain\_id         | integer(int32) | false    | none         | none        |
-| error             | string         | false    | none         | none        |
-| error\_event\_idx | integer(int32) | false    | none         | none        |
+| Name             | Type           | Required | Restrictions | Description              |
+|------------------|----------------|----------|--------------|--------------------------|
+| table_id         | string         | false    | none         | This field is deprecated |
+| table_ids        | \[string\]     | false    | none         | none                     |
+| transaction_hash | string         | false    | none         | none                     |
+| block_number     | integer(int64) | false    | none         | none                     |
+| chain_id         | integer(int32) | false    | none         | none                     |
+| error            | string         | false    | none         | none                     |
+| error_event_idx  | integer(int32) | false    | none         | none                     |
 
 <h2 id="tocS_Schema">
 Schema
@@ -493,10 +502,10 @@ Schema
 
 ### Properties
 
-| Name               | Type                        | Required | Restrictions | Description |
-|--------------------|-----------------------------|----------|--------------|-------------|
-| columns            | \[[Column](#schemacolumn)\] | false    | none         | none        |
-| table\_constraints | \[string\]                  | false    | none         | none        |
+| Name              | Type                        | Required | Restrictions | Description |
+|-------------------|-----------------------------|----------|--------------|-------------|
+| columns           | \[[Column](#schemacolumn)\] | false    | none         | none        |
+| table_constraints | \[string\]                  | false    | none         | none        |
 
 <h2 id="tocS_Column">
 Column
@@ -548,12 +557,12 @@ VersionInfo
 
 ### Properties
 
-| Name            | Type           | Required | Restrictions | Description |
-|-----------------|----------------|----------|--------------|-------------|
-| version         | integer(int32) | false    | none         | none        |
-| git\_commit     | string         | false    | none         | none        |
-| git\_branch     | string         | false    | none         | none        |
-| git\_state      | string         | false    | none         | none        |
-| git\_summary    | string         | false    | none         | none        |
-| build\_date     | string         | false    | none         | none        |
-| binary\_version | string         | false    | none         | none        |
+| Name           | Type           | Required | Restrictions | Description |
+|----------------|----------------|----------|--------------|-------------|
+| version        | integer(int32) | false    | none         | none        |
+| git_commit     | string         | false    | none         | none        |
+| git_branch     | string         | false    | none         | none        |
+| git_state      | string         | false    | none         | none        |
+| git_summary    | string         | false    | none         | none        |
+| build_date     | string         | false    | none         | none        |
+| binary_version | string         | false    | none         | none        |

--- a/specs/validator/README.md
+++ b/specs/validator/README.md
@@ -230,7 +230,7 @@ Parameters
   "name": "healthbot_80001_1",
   "external_url": "https://testnets.tableland.network/api/v1/tables/80001/1",
   "animation_url": "https://tables.testnets.tableland.xyz/80001/1.html",
-  "image": "https://tables.testnets.tableland.xyz/healthbot_80001_1",
+  "image": "https://tables.testnets.tableland.xyz/80001/1.svg",
   "attributes": {
     "display_type": "date",
     "trait_type": "created",
@@ -363,7 +363,7 @@ Table
   "name": "healthbot_80001_1",
   "external_url": "https://testnets.tableland.network/api/v1/tables/80001/1",
   "animation_url": "https://tables.testnets.tableland.xyz/80001/1.html",
-  "image": "https://tables.testnets.tableland.xyz/healthbot_80001_1",
+  "image": "https://tables.testnets.tableland.xyz/80001/1.svg",
   "attributes": {
     "display_type": "date",
     "trait_type": "created",

--- a/specs/validator/Specification.md
+++ b/specs/validator/Specification.md
@@ -1,6 +1,6 @@
 <!-- Generator: Widdershins v4.0.1 -->
 
-<h1 id="tableland-validator-openapi-3-0">Tableland Validator - OpenAPI 3.0 v1.0.0</h1>
+<h1 id="tableland-validator-openapi-3-0">Tableland Validator - OpenAPI 3.0 v1.0.1</h1>
 
 > Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
 
@@ -129,6 +129,10 @@ Returns the status of a given transaction receipt by hash
 ```json
 {
   "table_id": "1",
+  "table_ids": [
+    "1",
+    "2"
+  ],
   "transaction_hash": "0x02f319429b8a7be1cbb492f0bfbf740d2472232a2edadde7df7c16c0b61aa78b",
   "block_number": 27055540,
   "chain_id": 80001,
@@ -187,9 +191,9 @@ Returns information about a single table, including schema information
 ```json
 {
   "name": "healthbot_5_1",
-  "external_url": "https://testnet.tableland.network/tables/healthbot_5_1",
-  "animation_url": "https://render.tableland.xyz/anim/?chain=1&id=1",
-  "image": "https://render.tableland.xyz/healthbot_5_1",
+  "external_url": "https://testnets.tableland.network/api/v1/tables/healthbot_5_1",
+  "animation_url": "https://tables.tableland.xyz/1/1.html",
+  "image": "https://tables.tableland.xyz/healthbot_5_1",
   "attributes": {
     "display_type": "date",
     "trait_type": "created",
@@ -313,9 +317,9 @@ This operation does not require authentication
 ```json
 {
   "name": "healthbot_5_1",
-  "external_url": "https://testnet.tableland.network/tables/healthbot_5_1",
-  "animation_url": "https://render.tableland.xyz/anim/?chain=1&id=1",
-  "image": "https://render.tableland.xyz/healthbot_5_1",
+  "external_url": "https://testnets.tableland.network/api/v1/tables/healthbot_5_1",
+  "animation_url": "https://tables.tableland.xyz/1/1.html",
+  "image": "https://tables.tableland.xyz/healthbot_5_1",
   "attributes": {
     "display_type": "date",
     "trait_type": "created",
@@ -400,6 +404,10 @@ continued
 ```json
 {
   "table_id": "1",
+  "table_ids": [
+    "1",
+    "2"
+  ],
   "transaction_hash": "0x02f319429b8a7be1cbb492f0bfbf740d2472232a2edadde7df7c16c0b61aa78b",
   "block_number": 27055540,
   "chain_id": 80001,
@@ -413,7 +421,8 @@ continued
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|table_id|string|false|none|none|
+|table_id|string|false|none|This field is deprecated|
+|table_ids|[string]|false|none|none|
 |transaction_hash|string|false|none|none|
 |block_number|integer(int64)|false|none|none|
 |chain_id|integer(int32)|false|none|none|

--- a/specs/validator/Specification.md
+++ b/specs/validator/Specification.md
@@ -193,7 +193,7 @@ Returns information about a single table, including schema information
   "name": "healthbot_80001_1",
   "external_url": "https://testnets.tableland.network/api/v1/tables/80001/1",
   "animation_url": "https://tables.testnets.tableland.xyz/80001/1.html",
-  "image": "https://tables.testnets.tableland.xyz/healthbot_80001_1",
+  "image": "https://tables.testnets.tableland.xyz/80001/1.svg",
   "attributes": {
     "display_type": "date",
     "trait_type": "created",
@@ -319,7 +319,7 @@ This operation does not require authentication
   "name": "healthbot_80001_1",
   "external_url": "https://testnets.tableland.network/api/v1/tables/80001/1",
   "animation_url": "https://tables.testnets.tableland.xyz/80001/1.html",
-  "image": "https://tables.testnets.tableland.xyz/healthbot_80001_1",
+  "image": "https://tables.testnets.tableland.xyz/80001/1.svg",
   "attributes": {
     "display_type": "date",
     "trait_type": "created",

--- a/specs/validator/Specification.md
+++ b/specs/validator/Specification.md
@@ -190,10 +190,10 @@ Returns information about a single table, including schema information
 
 ```json
 {
-  "name": "healthbot_5_1",
-  "external_url": "https://testnets.tableland.network/api/v1/tables/healthbot_5_1",
-  "animation_url": "https://tables.tableland.xyz/1/1.html",
-  "image": "https://tables.tableland.xyz/healthbot_5_1",
+  "name": "healthbot_80001_1",
+  "external_url": "https://testnets.tableland.network/api/v1/tables/80001/1",
+  "animation_url": "https://tables.testnets.tableland.xyz/80001/1.html",
+  "image": "https://tables.testnets.tableland.xyz/healthbot_80001_1",
   "attributes": {
     "display_type": "date",
     "trait_type": "created",
@@ -316,10 +316,10 @@ This operation does not require authentication
 
 ```json
 {
-  "name": "healthbot_5_1",
-  "external_url": "https://testnets.tableland.network/api/v1/tables/healthbot_5_1",
-  "animation_url": "https://tables.tableland.xyz/1/1.html",
-  "image": "https://tables.tableland.xyz/healthbot_5_1",
+  "name": "healthbot_80001_1",
+  "external_url": "https://testnets.tableland.network/api/v1/tables/80001/1",
+  "animation_url": "https://tables.testnets.tableland.xyz/80001/1.html",
+  "image": "https://tables.testnets.tableland.xyz/healthbot_80001_1",
   "attributes": {
     "display_type": "date",
     "trait_type": "created",

--- a/specs/validator/tableland-openapi-spec.yaml
+++ b/specs/validator/tableland-openapi-spec.yaml
@@ -213,7 +213,7 @@ components:
           example: https://tables.testnets.tableland.xyz/80001/1.html
         image:
           type: string
-          example: https://tables.testnets.tableland.xyz/healthbot_80001_1
+          example: https://tables.testnets.tableland.xyz/80001/1.svg
         attributes:
           type: array
           items:

--- a/specs/validator/tableland-openapi-spec.yaml
+++ b/specs/validator/tableland-openapi-spec.yaml
@@ -204,16 +204,16 @@ components:
       properties:
         name:
           type: string
-          example: healthbot_5_1
+          example: healthbot_80001_1
         external_url:
           type: string
-          example: https://testnets.tableland.network/api/v1/tables/healthbot_5_1
+          example: https://testnets.tableland.network/api/v1/tables/80001/1
         animation_url:
           type: string
-          example: https://tables.tableland.xyz/1/1.html
+          example: https://tables.testnets.tableland.xyz/80001/1.html
         image:
           type: string
-          example: https://tables.tableland.xyz/healthbot_5_1
+          example: https://tables.testnets.tableland.xyz/healthbot_80001_1
         attributes:
           type: array
           items:

--- a/specs/validator/tableland-openapi-spec.yaml
+++ b/specs/validator/tableland-openapi-spec.yaml
@@ -210,10 +210,10 @@ components:
           example: https://testnets.tableland.network/api/v1/tables/healthbot_5_1
         animation_url:
           type: string
-          example: https://render.tableland.xyz/anim/?chain=1&id=1
+          example: https://tables.tableland.xyz/1/1.html
         image:
           type: string
-          example: https://render.tableland.xyz/healthbot_5_1
+          example: https://tables.tableland.xyz/healthbot_5_1
         attributes:
           type: array
           items:
@@ -248,6 +248,12 @@ components:
         table_id:
           type: string
           example: "1"
+          deprecated: true 
+        table_ids:
+          type: array
+          items:
+            type: string
+          example: ["1", "2"]
         transaction_hash:
           type: string
           example: "0x02f319429b8a7be1cbb492f0bfbf740d2472232a2edadde7df7c16c0b61aa78b"

--- a/specs/validator/tableland-openapi-spec.yaml
+++ b/specs/validator/tableland-openapi-spec.yaml
@@ -19,7 +19,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-  version: 1.0.0
+  version: 1.0.1
 externalDocs:
   description: Tableland docs
   url: http://docs.tableland.xyz
@@ -249,6 +249,7 @@ components:
           type: string
           example: "1"
           deprecated: true 
+          description: "This field is deprecated"
         table_ids:
           type: array
           items:


### PR DESCRIPTION
The PR changes our Gateway API Spec to include `table_ids` and deprecates `table_id` in `TransactionReceipt` response. 

The reason for that change is that we allow a transaction to execute multiple events and each of these events may touch different tables. The receipt should be able to indicate all tables that were touched. 

See https://github.com/tablelandnetwork/go-tableland/issues/522