### PR TITLE
feat: add 'how to build an nft' index page

### DIFF
--- a/config/sidebars.js
+++ b/config/sidebars.js
@@ -156,6 +156,8 @@ const quickstarts = [
   "quickstarts/wagmi",
   ...section("Contract frameworks"),
   "quickstarts/hardhat",
+  ...section("Guides"),
+  "quickstarts/how-to-build-an-nft",
 ];
 
 // SDK

--- a/docs/fundamentals/concepts/nft-metadata.md
+++ b/docs/fundamentals/concepts/nft-metadata.md
@@ -2,6 +2,7 @@
 title: NFT metadata
 description: Understand the basics of storing and querying ERC721 metadata in table.
 keywords:
+  - nfts
   - nft metadata
   - erc721 metadata
 ---
@@ -121,3 +122,7 @@ Thus, when an NFT is rendered somewhere, the associated `value` would also chang
   "value": "red" // Previously, was `blue`
 }
 ```
+
+## Next steps
+
+Looking for more? Check out the page on [how to build an NFT](/how-to-build-an-nft), including additional resources for defining an [optimal SQL table structure](/playbooks/walkthroughs/nft-metadata) or [building a dynamic NFT in Solidity](/tutorials/dynamic-nft-solidity).

--- a/docs/fundamentals/use-cases/README.md
+++ b/docs/fundamentals/use-cases/README.md
@@ -27,6 +27,10 @@ The TL;DR is that Tableland can be used as a data storage option with on-chain d
 - Cross-chain table storage for multichain NFTs where metadata is composed at the NFT smart contract.
 - Global leaderboards, game state, user settings, character inventory, or anything that needs a way to store game data in a permissionless database.
 
+:::tip
+Looking for more? Check out the page on [how to build an NFT](/how-to-build-an-nft), including additional resources for defining an [optimal SQL table structure](/playbooks/walkthroughs/nft-metadata) or [building a dynamic NFT in Solidity](/tutorials/dynamic-nft-solidity).
+:::
+
 ### Data DAOs & token gating
 
 - Storing large media on file storage networks (IPFS, Filecoin, etc.) where pointers and metadata exist in tables.

--- a/docs/playbooks/walkthroughs/nft-metadata.md
+++ b/docs/playbooks/walkthroughs/nft-metadata.md
@@ -232,3 +232,7 @@ WHERE id = <id> GROUP BY <id>;
 ```
 
 The JSON response is the same as before but much more future-proof and ready for dynamism. You could also choose to add other columns, such as an `animation_base_url` or similar.
+
+## Next steps
+
+Looking for more? Check out the page on [how to build an NFT](/how-to-build-an-nft), including additional resources for defining an [optimal SQL table structure](/playbooks/walkthroughs/nft-metadata) or [building a dynamic NFT in Solidity](/tutorials/dynamic-nft-solidity).

--- a/docs/quickstarts/how-to-build-an-nft.md
+++ b/docs/quickstarts/how-to-build-an-nft.md
@@ -1,0 +1,30 @@
+---
+title: How to build an NFT
+sidebar_label: Build an NFT
+description: Store NFT metadata in tables that capture chain-driven data changes.
+keywords:
+  - nft metadata
+  - erc721 metadata
+  - how to build an nft
+slug: /how-to-build-an-nft
+---
+
+Tableland closes the gap between on-chain and off-chain state synchronicity, which is especially useful for NFT developers. Namely, on-chain can automatically drive off-chain metadata changes while also offering performant query capabilities at the application layer.
+
+## Learn
+
+To get started, check out the following pages that provide general NFT metadata overviews and Tableland SQL usage:
+
+- [NFT metadata standards](/fundamentals/concepts/nft-metadata): A 101 about NFT metadata and the various standards used in web3.
+- [SQL table design](/playbooks/walkthroughs/nft-metadata): Learn about how you can structure data across one or more tables and compose the metadata using SQL + JSON functions.
+- [NFT uses cases](/fundamentals/use-cases#nfts--gaming): Dive into basics about what you can build with NFTs, including how web3 gaming can benefit from using Tableland.
+
+## Develop
+
+For those looking to build, the following highlight how to use smart contracts and/or the Tableland SDK for NFT metadata:
+
+- [Serving NFT metadata](/smart-contracts/serving-nft-metadata): Gain familiarity with how a smart contract can serve NFT metadata using SQL queries to the Tableland gateway.
+- [URI encoding](/smart-contracts/uri-encoding): Use JavaScript in smart contract deploy scripts to set a token URI with the proper encoding.
+- [Build a dynamic NFT in Solidity](/tutorials/dynamic-nft-solidity): Get started with the basics of a Solidity-based NFT game that uses SQL queries to create and populate a table of game state.
+- [Creating a dynamic NFT with p5.js](/tutorials/dynamic-nft-p5js): Add visual components to the intro tutorial about that walks through building a dynamic NFT in Solidity.
+- [JSON files to NFT metadata](/tutorials/json-files-nft-polygon): With a Hardhat project, take local JSON files, read/parse the data into tables, and then mint an NFT where Tableland powers the metadata.

--- a/docs/smart-contracts/examples/gated-voting.md
+++ b/docs/smart-contracts/examples/gated-voting.md
@@ -1,6 +1,10 @@
 ---
 title: Gated voting
 description: Create a contract that gates writes to a voting table based on ERC721 token ownership.
+keywords:
+  - token gating
+  - nft gating
+  - dao voting
 ---
 
 Collaborative data often needs some way to permissionlessly ensure only the correct users can change table data. For example, a DAO could have some knowledge base or protocol decision that anyone with DAO token ownership can cast a vote. This setup established both a questions and an answers table:
@@ -125,6 +129,8 @@ contract TablelandVoter is ITablelandController {
 ```
 
 ## NFT contract
+
+Below is a basic NFT contract, but if you're trying to create your own NFT using Tableland, check out the page on [how to build an NFT](/how-to-build-an-nft). It outlines additional resources like defining an [optimal SQL table structure](/playbooks/walkthroughs/nft-metadata) or [building a dynamic NFT in Solidity](/tutorials/dynamic-nft-solidity).
 
 ```solidity
 // SPDX-License-Identifier: MIT

--- a/docs/smart-contracts/serving-nft-metadata.md
+++ b/docs/smart-contracts/serving-nft-metadata.md
@@ -3,7 +3,9 @@ title: Serve NFT metadata from smart contracts
 sidebar_label: Serve NFT metadata
 description: Learn how to write, format, and deploy SQL in your smart contracts to produce NFT JSON metadata.
 keywords:
-  - create table
+  - nft metadata
+  - erc721 metadata
+  - solidity nft
 ---
 
 Now that you have data stored as tables, you’ll need to serve it as metadata JSON so that marketplaces, wallets, and platforms can all pick it up for display. In short, you want to take a URL like this one:
@@ -25,6 +27,10 @@ https://testnets.tableland.network/query?unwrap=true&extract=true&s=SELECT json_
 ```
 
 ...and serve it from your smart contract so that apps trying to display your token can read each NFT metadata response one at a time. To do this, you’ll need to leverage the `tokenURI` or `uri` endpoints in your smart contracts.
+
+:::tip
+Looking for more? Check out the page on [how to build an NFT](/how-to-build-an-nft), including additional resources for defining an [optimal SQL table structure](/playbooks/walkthroughs/nft-metadata) or [building a dynamic NFT in Solidity](/tutorials/dynamic-nft-solidity).
+:::
 
 ## ERC721 tokenURIs
 

--- a/docs/smart-contracts/uri-encoding.md
+++ b/docs/smart-contracts/uri-encoding.md
@@ -105,3 +105,7 @@ function tokenURI(string memory _tableName) public view returns (string memory) 
 ```
 
 The main callout—this `tokenURI` method produced the percent encoded URI (`"SELECT%20%2A%20FROM%20"`) outside of Solidity.
+
+## Next steps
+
+Looking for more? Check out the page on [how to build an NFT](/how-to-build-an-nft), including additional resources for defining an [optimal SQL table structure](/playbooks/walkthroughs/nft-metadata) or [building a dynamic NFT in Solidity](/tutorials/dynamic-nft-solidity).

--- a/docs/tutorials/dynamic-nft-p5js.md
+++ b/docs/tutorials/dynamic-nft-p5js.md
@@ -2,9 +2,9 @@
 title: Create a dynamic NFT with p5.js
 description: Use p5.js to render data from an NFT that holds global game state in a table.
 keywords:
-  - tutorial
-  - solidity
-  - dynamic NFT
+  - nft metadata
+  - dynamic nft
+  - p5js
 ---
 
 We want to now write a simple web app that will be used to dynamically render a single NFT in our collection. When the NFT renders, the web app should check the requested token, grab the latest data from Tableland, and render some dynamic content.
@@ -20,13 +20,16 @@ If you aren’t familiar with [p5.js](https://p5js.org/), it’s an awesome litt
 - Completed the steps & tutorial to [build a dynamic NFT in Solidity](/tutorials/dynamic-nft-solidity).
 - (Optional) for pushing to production, sign up for an [NFT.Storage](https://nft.storage/) account
 
-## Setting up Your p5.js App
+## Setting up your p5.js app
 
 To start this tutorial, we’re going to lean on some great starter content written by others. Follow the instructions in [How to use p5.js with Typescript and webpack](https://dev.to/tendonnman/how-to-use-p5js-with-typescript-and-webpack-57ae).
 
-[How to use p5.js with TypeScript and webpack](https://dev.to/tendonnman/how-to-use-p5js-with-typescript-and-webpack-57ae)
-
 When you are finished with the tutorial, you should be able to run `npm run start` and see the simple data viz in your browser.
+
+:::tip
+
+Looking for more? Check out the page on [how to build an NFT](/how-to-build-an-nft), including additional resources like defining an [optimal SQL table structure](/playbooks/walkthroughs/nft-metadata).
+:::
 
 ## Customizing p5.js for an NFT
 
@@ -60,7 +63,7 @@ Let’s just get this ready for a full-bleed token. We’ll add a black backgrou
 </style>
 ```
 
-### A Basic p5js NFT Canvas
+### A basic p5js NFT canvas
 
 Your `index.ts` file should currently look like the following:
 
@@ -147,7 +150,7 @@ p.setup = () => {
 
 Awesome. We’re ready to start drawing!
 
-### Getting Table Data
+### Getting table data
 
 First, it’s time to install `@tableland/sdk` in your project.
 
@@ -181,7 +184,7 @@ p.setup = () => {
 
 That’s it, you’ll have have Tableland data in your app. It’s time to draw it.
 
-### Rendering Table Data
+### Rendering table data
 
 To render the data, we’ll rewrite the `p.draw()` function to loop over the points and render them on our canvas.
 
@@ -213,15 +216,15 @@ import GameScreen from "@site/static/assets/tutorials/dynamic-nft-p5js/game-scre
 
 You may not have the aqua point highlighted. To see the token view for any single token, you need to change your url to `[https://localhost/#{id}](https://localhost/#{id})`. So to see tokenId=1 as shown above, you’d go to `[http://localhost/#1](http://localhost/#1)`.
 
-## Package for Production
+## Package for production
 
 The tutorial above left your project with a couple more config steps to get ready for production.
 
-### Change webpack to Production
+### Change webpack to production
 
 In `webpack.config.js` change `mode: "development",` to `mode: "production",`.
 
-### Add a Build Script
+### Add a build script
 
 in `package.json` add a new method to your scripts, _`"build"_: "webpack build"`. So, your full script options looks like:
 
@@ -233,7 +236,7 @@ in `package.json` add a new method to your scripts, _`"build"_: "webpack build"`
 },
 ```
 
-### Run the Build
+### Run the build
 
 `npm run build`
 

--- a/docs/tutorials/dynamic-nft-solidity.md
+++ b/docs/tutorials/dynamic-nft-solidity.md
@@ -2,13 +2,12 @@
 title: Build a dynamic NFT in Solidity
 description: Create an on-chain game that uses SQL queries to create and populate a table of game state.
 keywords:
-  - tutorial
-  - solidity
-  - dynamic NFT
-  - p5.js
+  - dynamic nft
+  - nft metadata
+  - nft solidity
 ---
 
-Tableland enables ownership & on-chain rules to dictate table state mutation. For every mutation, the data is accessible with off-chain queries that can be displayed in an interface, such as an NFT-based game board. This tutorial walks through the basics of Solidity ERC721s and an app with shared state.
+Tableland enables ownership & on-chain rules to dictate table state mutation. For every mutation, the data is accessible with off-chain queries that can be displayed in an interface, such as an NFT-based game board. This tutorial walks through the basics of Solidity ERC721s and an app with shared state. Note that in the [second part of this tutorial](/tutorials/dynamic-nft-p5js.md), you'll use `p5.js` to add a visualization component to the app!
 
 ## Overview
 
@@ -23,6 +22,10 @@ import GameBoard from "@site/static/assets/tutorials/dynamic-nft-solidity/game-b
 When you build the game, you want users to own their pixels as an NFT. So, we can think of the game's architecture in two parts. The first part is an ERC-721 smart contract where users can mint pixels and then update the coordinates of pixels they own. The second part is a web app that displays the live locations of all the minted pixels and provides an interface for each owner to move their pixel. Today, we'll cover just the first part.
 
 The data's simplicity would make it great fun to build fully on-chain, but we'll use it to illustrate the basics of creating a smart contract that owns and populates relational data tables. Let's go!
+
+:::tip
+Looking for more? Check out the page on [how to build an NFT](/how-to-build-an-nft) to view additional resources for developing on Tableland, such as ERC721 compliant metadata standards.
+:::
 
 ### The NFT design
 

--- a/docs/tutorials/json-files-nft-polygon.md
+++ b/docs/tutorials/json-files-nft-polygon.md
@@ -4,8 +4,8 @@ sidebar_label: JSON files to tables & NFTs
 description: Take local JSON files, parse them into tables, and deploy the data as an NFT collection on Polygon.
 keywords:
   - polygon
-  - json
-  - dynamic nft
+  - json metadata
+  - nft metadata
 ---
 
 Tableland is a web3-native database that can be used to store data in relational tables. One of the most exciting use cases is using Tableland for _[NFT metadata](https://docs.opensea.io/docs/metadata-standards)_—which is a challenging problem in web3, especially for novel _dynamic NFT_ use cases. Developers must make tradeoffs between:
@@ -13,6 +13,10 @@ Tableland is a web3-native database that can be used to store data in relational
 - Expensive on-chain storage with very limited query-ability
 - Centralized storage, which doesn’t _enable_ web3 paradigms
 - Decentralized storage (e.g., IPFS), which is _great_ for file/image storage, but immutable files (CIDs) pose a challenge for novel NFT metadata use cases
+
+:::tip
+New to NFTs? Check out the page on [how to build an NFT](/how-to-build-an-nft), including additional resources for defining an [optimal SQL table structure](/playbooks/walkthroughs/nft-metadata) or [building a dynamic NFT in Solidity](/tutorials/dynamic-nft-solidity).
+:::
 
 ## Overview
 


### PR DESCRIPTION
There are a number of NFT-focused pages, but there is not a single one that unifies everything together. Adding this helps with SEO as well as simplifies link sharing. Additionlly, some of the SEO keywords per page have been updated, and the 'sidebars' also now include this index page in the 'Quickstarts' section.