### PR TITLE
feat: more local tableland docs (incl. registry port), other cleanups

### DIFF
--- a/config/navbar.js
+++ b/config/navbar.js
@@ -73,6 +73,11 @@ const navbar = {
         },
         {
           type: "docSidebar",
+          sidebarId: "localTableland",
+          label: "Local Tableland",
+        },
+        {
+          type: "docSidebar",
           sidebarId: "tutorials",
           label: "Tutorials",
         },

--- a/config/sidebars.js
+++ b/config/sidebars.js
@@ -298,6 +298,14 @@ const cli = [
   "cli/errors",
 ];
 
+// Local Tableland
+const localTableland = [
+  ...sidepageHeader("Local Tableland"),
+  "local-tableland/README",
+  "local-tableland/cli",
+  "local-tableland/testing",
+];
+
 // Tutorials
 const tutorials = [
   ...sidepageHeader("Tutorials"),
@@ -381,6 +389,12 @@ const sidebars = {
     },
     {
       type: "doc",
+      id: "local-tableland/README",
+      label: "Local Tableland",
+      className: "sidebar-landing",
+    },
+    {
+      type: "doc",
       id: "tutorials/README",
       label: "Tutorials",
       className: "sidebar-landing",
@@ -419,19 +433,20 @@ const sidebars = {
     },
   ],
   // Learn
-  fundamentals: fundamentals,
-  playbooks: playbooks,
+  fundamentals,
+  playbooks,
   // Develop
-  quickstarts: quickstarts,
-  sdk: sdk,
-  smartContracts: smartContracts,
-  cli: cli,
-  gatewayApi: gatewayApi,
-  tutorials: tutorials,
-  apiSdk: apiSdk,
+  quickstarts,
+  sdk,
+  smartContracts,
+  cli,
+  gatewayApi,
+  localTableland,
+  tutorials,
+  apiSdk,
   // Infra & protocol
-  validator: validator,
-  sqlSpecification: sqlSpecification,
+  validator,
+  sqlSpecification,
   // Miscellaneous
   contribute: [
     ...sidepageHeader("Contribute"),

--- a/docs/api/sdk/classes/helpers.TableEventBus.md
+++ b/docs/api/sdk/classes/helpers.TableEventBus.md
@@ -1,0 +1,213 @@
+---
+id: "helpers.TableEventBus"
+title: "Class: TableEventBus"
+sidebar_label: "TableEventBus"
+custom_edit_url: null
+---
+
+[helpers](../namespaces/helpers.md).TableEventBus
+
+TableEventBus provides a way to listen for:
+ mutations, transfers, and changes to controller
+
+## Constructors
+
+### constructor
+
+• **new TableEventBus**(`config?`)
+
+Create a TableEventBus instance with the specified connection configuration.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `config` | `Partial`<`Partial`<[`ReadConfig`](../interfaces/helpers.ReadConfig.md) & [`SignerConfig`](../interfaces/helpers.SignerConfig.md)\>\> | The connection configuration. This must include an ethersjs Signer. If passing the config from a pre-existing Database instance, it must have a non-null signer key defined. |
+
+#### Defined in
+
+@tableland/sdk/src/helpers/subscribe.ts:77
+
+## Properties
+
+### config
+
+• `Readonly` **config**: `Partial`<[`ReadConfig`](../interfaces/helpers.ReadConfig.md) & [`SignerConfig`](../interfaces/helpers.SignerConfig.md)\>
+
+#### Defined in
+
+@tableland/sdk/src/helpers/subscribe.ts:67
+
+___
+
+### contracts
+
+• `Readonly` **contracts**: `ContractMap`
+
+#### Defined in
+
+@tableland/sdk/src/helpers/subscribe.ts:68
+
+___
+
+### listeners
+
+• `Readonly` **listeners**: `ListenerMap`
+
+#### Defined in
+
+@tableland/sdk/src/helpers/subscribe.ts:69
+
+## Methods
+
+### \_attachEmitter
+
+▸ **_attachEmitter**(`contract`, `emitter`, `tableIdentifier`): `ContractEventListener`[]
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `contract` | `TablelandTables` |
+| `emitter` | `EventEmitter` |
+| `tableIdentifier` | [`TableIdentifier`](../interfaces/TableIdentifier.md) |
+
+#### Returns
+
+`ContractEventListener`[]
+
+#### Defined in
+
+@tableland/sdk/src/helpers/subscribe.ts:224
+
+___
+
+### \_ensureListening
+
+▸ **_ensureListening**(`listenerId`, `emitter`): `Promise`<`ContractEventListener`[]\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `listenerId` | `string` |
+| `emitter` | `EventEmitter` |
+
+#### Returns
+
+`Promise`<`ContractEventListener`[]\>
+
+#### Defined in
+
+@tableland/sdk/src/helpers/subscribe.ts:214
+
+___
+
+### \_getContract
+
+▸ **_getContract**(`chainId`): `Promise`<`TablelandTables`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `chainId` | `number` |
+
+#### Returns
+
+`Promise`<`TablelandTables`\>
+
+#### Defined in
+
+@tableland/sdk/src/helpers/subscribe.ts:198
+
+___
+
+### addListener
+
+▸ **addListener**(`tableName`): `Promise`<`EventEmitter`\>
+
+Start listening to the Registry Contract for events that are associated
+with a given table.
+There's only ever one "listener" for a table, but the emitter that
+Contract listener has can have as many event listeners as the environment
+supports.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `tableName` | `string` | The full name of table that you want to listen for changes to. |
+
+#### Returns
+
+`Promise`<`EventEmitter`\>
+
+#### Defined in
+
+@tableland/sdk/src/helpers/subscribe.ts:97
+
+___
+
+### addTableIterator
+
+▸ **addTableIterator**<`T`\>(`tableName`): `Promise`<`AsyncIterable`<`T`\>\>
+
+A simple wrapper around `addListener` that returns an async iterable
+which can be used with the for await ... of pattern.
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `tableName` | `string` | The full name of table that you want to listen for changes to. |
+
+#### Returns
+
+`Promise`<`AsyncIterable`<`T`\>\>
+
+#### Defined in
+
+@tableland/sdk/src/helpers/subscribe.ts:132
+
+___
+
+### removeAllListeners
+
+▸ **removeAllListeners**(): `void`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+@tableland/sdk/src/helpers/subscribe.ts:163
+
+___
+
+### removeListener
+
+▸ **removeListener**(`params`): `void`
+
+Remove a listener (or iterator) based on chain and tableId
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `params` | [`TableIdentifier`](../interfaces/TableIdentifier.md) | A TableIdentifier Object. Must have `chainId` and `tableId` keys. |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+@tableland/sdk/src/helpers/subscribe.ts:145

--- a/docs/api/sdk/interfaces/helpers.AliasesNameMap.md
+++ b/docs/api/sdk/interfaces/helpers.AliasesNameMap.md
@@ -1,0 +1,50 @@
+---
+id: "helpers.AliasesNameMap"
+title: "Interface: AliasesNameMap"
+sidebar_label: "AliasesNameMap"
+custom_edit_url: null
+---
+
+[helpers](../namespaces/helpers.md).AliasesNameMap
+
+## Properties
+
+### read
+
+• **read**: () => `Promise`<[`NameMapping`](../namespaces/helpers.md#namemapping)\>
+
+#### Type declaration
+
+▸ (): `Promise`<[`NameMapping`](../namespaces/helpers.md#namemapping)\>
+
+##### Returns
+
+`Promise`<[`NameMapping`](../namespaces/helpers.md#namemapping)\>
+
+#### Defined in
+
+@tableland/sdk/src/helpers/config.ts:24
+
+___
+
+### write
+
+• **write**: (`map`: [`NameMapping`](../namespaces/helpers.md#namemapping)) => `Promise`<`void`\>
+
+#### Type declaration
+
+▸ (`map`): `Promise`<`void`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `map` | [`NameMapping`](../namespaces/helpers.md#namemapping) |
+
+##### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+@tableland/sdk/src/helpers/config.ts:25

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -6,7 +6,7 @@ keywords:
   - command line
 ---
 
-The `@tableland/cli` is a developer tool to help you connect, create, write, and read from The comfort of your command line. It’s simple, easy to use, and integrates nicely with tools like [jq](https://stedolan.github.io/jq/). When interacting with the Tableland CLI, you can also specify your own [provider endpoints](https://www.alchemy.com/blog/what-is-a-node-provider) for added control. Using the CLI, you can:
+The `@tableland/cli` package is a developer tool to help you connect, create, write, and read from The comfort of your command line. It’s simple, easy to use, and integrates nicely with tools like [jq](https://stedolan.github.io/jq/). When interacting with the Tableland CLI, you can also specify your own [provider endpoints](https://www.alchemy.com/blog/what-is-a-node-provider) for added control. Using the CLI, you can:
 
 - Connect to any of the chains that Tableland supports.
 - Create, write to, and read from tables.

--- a/docs/fundamentals/about/glossary.md
+++ b/docs/fundamentals/about/glossary.md
@@ -125,7 +125,7 @@ Reading data is to observe and extrapolate learnings from it without altering it
 
 ### Registry
 
-Tableland is one part on-chain, another part off-chain. The on-chain component is a "registry" smart contract that accepts SQL statements, thus, minting tables and providing data availability of SQL. Without the registry, you wouldn't be able to create nor mutate tables. The Off-chain part is the Tableland network of validators that materialized the data.
+Tableland is one part on-chain, another part off-chain. The on-chain component is a "registry" smart contract that accepts SQL statements, thus, minting tables and providing data availability of SQL. Without the registry, you wouldn't be able to create nor mutate tables. The off-chain part is the Tableland network of validators that materialized the data.
 
 ## S
 

--- a/docs/local-tableland/README.md
+++ b/docs/local-tableland/README.md
@@ -1,0 +1,117 @@
+---
+title: Overview
+description: Local-first development with a sandboxed Tableland validator and hardhat node.
+keywords:
+  - local tableland
+  - hardhat
+  - development
+  - testing
+---
+
+The `@tableland/local` package is a tool that works with any of the other Tableland clients. Commonly, you'll spin up Local Tableland via the command line, and for testing, you'll import a `LocalTableland` instance into your JavaScript code. It allows developers to create a local Tableland validator and hardhat node, which can be used for local development and testing. This is useful for developers who want to test their Tableland applications locally before deploying to a live chain.
+
+:::tip
+See the [quickstart page](/quickstarts/local-tableland) if you’re looking to get up and running without all of the details.
+:::
+
+## Startup & logging
+
+Starting `local-tableland` will provide logging for both the local hardhat blockchain and the Local Tableland network. This will happen irrespective of the method you're using it. Note there are optional `silent` and `verbose` flags for silencing the logs or making them verbose.
+
+If no flags are passed, the default logging will resemble the following, which starts a Local Tableland server on port `http://localhost:8080` and a hardhat node on `http://127.0.0.1:8545`:
+
+```bash
+[Registry] Started HTTP and WebSocket JSON-RPC server at http://127.0.0.1:8545/
+[Registry]
+[Registry]
+[Registry] Accounts
+[Registry] ========
+---
+[Registry] eth_sendTransaction
+[Registry] Contract deployment: TablelandTables
+[Registry] Contract address:    0x5fbdb2315678afecb367f032d93f642f64180aa3
+---
+[Validator] 8:26PM INF state hash block_number=6 chain_id=31337 component=eventprocessor elapsed_time=5 goversion=go1.19.1 hash=edde6a99dd8d30efb48f8a60de13f53b84a6c6f1 severity=Info version=7144099
+[Validator]
+[Validator] 8:26PM DBG executing create-table event chain_id=31337 component=txnscope goversion=go1.19.1 owner=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 severity=Debug statement="create table healthbot_31337 (counter integer);" token_id=1 txn_hash=0x8459cc42f646c40233966c3ff366f16a4b6678045f23536c3a1839e459a8cd05 version=7144099
+```
+
+First, you’ll notice that each line is prefixed with either `[Registry]` or `[Validator]`, plus the local time at which the log occurred. The **Registry** logs are standard _hardhat node_ interactions. For example, when the `TablelandTables` contract is deployed, it shows up on a line with `[Registry]` and includes information passed by hardhat; the same information available with `npx hardhat node`.
+
+For lines prefixed with **Validator**, these are corresponding to the local _Tableland validator node._ Thus, a line like `[Validator] 8:26PM DBG executing create-table event ...` is an action executed by the local Tableland network node. In this case, it’s relating to a create table statement that was made, but for any table creation, mutation, or read, there will be a corresponding log with the `[Validator]` prefix.
+
+### Additional context
+
+Any time you start `local-tableland`, you’ll notice the same series of events that occur after the _Tableland is running!_ message:
+
+```bash
+******  Tableland is running!  ******
+             _________
+         ___/         \
+        /              \
+       /                \
+______/                  \______
+
+[Validator] 8:26PM INF state hash block_number=6 chain_id=31337 component=eventprocessor elapsed_time=5 goversion=go1.19.1 hash=edde6a99dd8d30efb48f8a60de13f53b84a6c6f1 severity=Info version=7144099
+[Validator]
+[Validator] 8:26PM DBG executing create-table event chain_id=31337 component=txnscope goversion=go1.19.1 owner=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 severity=Debug statement="create table healthbot_31337 (counter integer);" token_id=1 txn_hash=0x8459cc42f646c40233966c3ff366f16a4b6678045f23536c3a1839e459a8cd05 version=7144099
+[Validator]
+[Validator] 8:26PM DBG call ValidateCreateTable goversion=go1.19.1 query="create table healthbot_31337 (counter integer);" severity=Debug version=7144099
+[Validator]
+[Validator] 8:26PM DBG saved receipts chain_id=31337 component=eventprocessor goversion=go1.19.1 height=6 receipts=1 severity=Debug version=7144099
+[Validator]
+[Validator] 8:26PM DBG executing run-sql event chain_id=31337 component=txnscope goversion=go1.19.1 severity=Debug statement="insert into healthbot_31337_1 values (1);" txn_hash=0x0fccfecb3b7a692d2cb4fbb8a79c069a63d0351e1fa32dc00a3e8011b0880835 version=7144099
+[Validator]
+[Validator] 8:26PM DBG call ValidateMutatingQuery goversion=go1.19.1 query="insert into healthbot_31337_1 values (1);" severity=Debug version=7144099
+[Validator]
+[Validator] 8:26PM DBG saved receipts chain_id=31337 component=eventprocessor goversion=go1.19.1 height=7 receipts=1 severity=Debug version=7144099
+[Validator]
+```
+
+The _Validator_ events preceding _Tableland is running!_ are related to the node starting up:
+
+- Database (SQLite) is instantiated.
+- The node "owner" account is set to the 0th wallet provided by hardhat (`0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266`).
+- Various daemons and event trackers are set up.
+
+Then, the first table on the network — the `healthbot` table, consisting of a incrementing `counter` column — is created. Every testnet and mainnet chain that Tableland launches on actually follows the general logic in which this table is created as the first table on the new network. The following describes the steps that happen from this point onward:
+
+- With `executing create-table event ...`, you’ll notice this event comes along with the actual statement (`create table healthbot_31337 (counter integer)`) the table’s `owner`, and the transaction hash at which it was created (`txn_hash`).
+- The following line validates the create statement is valid (`ValidateCreateTable`) and saves the receipt of this create table event / transaction occurring.
+- From there, a `run-sql` event is processed due to the mutating query that is being sent with `insert into healthbot_31337_1 values (1)` (which also comes with a `txn_hash`).
+- The mutating query is validated (`ValidateMutatingQuery`) to ensure SQL compliance as well as the send of the query (who is the `owner`, in this case) has the process access.
+- Lastly, the table mutation is made, and the associated receipt is saved by the node; from there, the local Tableland network is ready to process new tables and queries!
+
+## Nonce too high errors
+
+If, for some reason, "nonce" errors do occur, such as the "Nonce too high" warning, which might look like the snippet below. Basically, if you were interacting with a local node, the nonce gets tracked for each on-chain action. When you stop the node, that history is maintained such that a new node session is using old nonce tracking. The new node session wants the nonce to start at `0`, but old history says the nonce starts at some other number.
+
+```json
+MetaMask - RPC Error: [ethjs-query] while formatting outputs from RPC '
+{
+  "value": {
+    "code":-32603,
+      "data": {
+        "code":-32000,
+          "message":"Nonce too high. Expected nonce to be 0 but got 50. Note that transactions can't be queued when automining.",
+        "data":{
+          "message":"Nonce too high. Expected nonce to be 0 but got 7. Note that transactions can't be queued when automining."
+      }
+    }
+  }
+}
+```
+
+There are a few resolution paths:
+
+1. If you’re using MetaMask, you can try to reset the transaction history by going to _Settings_ → _Advanced_ → _Reset Account_.
+
+import WalletReset from "@site/static/assets/metamask-reset.png"
+
+<img src={WalletReset} width='30%' />
+
+1.  Resetting your account will clear your transaction history. This will not change the balances in your accounts or require you to re-enter your Secret Recovery Phrase.
+2.  Again, this should only be done if you’re using some test account provided by hardhat.
+
+3.  Enable a "custom nonce" to manually set the nonce upon sending a transaction. Go to _Settings_ → _Advanced_ → _Customize transaction nonce_.
+4.  Delete the wallet and re-import it using the private key—be sure to \***\*only\*\*** delete and reimport the wallet if you do know the private key, or the account could be lost forever.

--- a/docs/local-tableland/cli.md
+++ b/docs/local-tableland/cli.md
@@ -1,0 +1,118 @@
+---
+title: Command line
+description: Run the sandboxed Tableland network from the command line.
+keywords:
+  - CLI
+  - command line
+  - local tableland
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+## Installation
+
+You can install the tool globally via `npm` or `yarn`.
+
+```bash npm2yarn
+npm install -g @tableland/local@latest
+```
+
+## Startup
+
+To start running the Local Tableland network, do the following:
+
+```bash
+npx local-tableland
+```
+
+This will start a Local Tableland server on port `http://localhost:8080` and a hardhat node on `http://127.0.0.1:8545`. For example, it's common that you'll pass the hardhat RPC URL to clients trying to send on-chain transactions. For querying the Tableland network via the [Gateway API](/gateway-api), you can use the Local Tableland URL, such as making read queries with the `query?statement=...` endpoint and query param.
+
+## Available flags
+
+There are a number of optional flags available:
+
+<!-- prettier-ignore -->
+| Flag             | Type                           | Description                               |
+| ---------------- | ------------------------------ | ----------------------------------------- |
+| `--help`         | `boolean`, defaults to `false` | Show help.                                |
+| `--version`      | `boolean`, defaults to `false` | Show the version number.                  |
+| `--silent`       | `boolean`, defaults to `false` | Silence all output to stdout.             |
+| `--verbose`      | `boolean`, defaults to `false` | Output verbose logs to stdout.            |
+| `--init`         | `boolean`, defaults to `false` | Initialize a Local Tableland config file. |
+| `--docker`       | `boolean`, defaults to `false` | Initialize a Local Tableland config file. |
+| `--validator`    | `string`                       | Path to the Tableland Validator directory (note: if the docker flag is set, this must be the full repository). |
+| `--registry`     | `string`                       | Path to the Tableland Registry contract repository. |
+| `--registryPort` | `string`                       | Use a custom Registry port for hardhat. |
+
+## Logging
+
+The `--verbose` flag allows you to see verbose logs from the Tableland validator node, which can be useful for debugging purposes. The `--silent` flag allows you to silence all logs from the Tableland validator node in case you'd like to run the node in the background. You can use these independently or together.
+
+<Tabs>
+<TabItem value='silent' label="silent" default>
+
+```bash
+npx local-tableland --silent
+```
+
+</TabItem>
+<TabItem value='verbose' label="verbose">
+
+```bash
+npx local-tableland --verbose
+```
+
+</TabItem>
+</Tabs>
+
+## Configuration
+
+The `init` option is optional and sets up a configuration file within your project. By default, the following `tableland.config.js` file comes with Local Tableland and is also what's created when running `npx local-tableland --init`:
+
+```js title="tableland.config.js"
+module.exports = {
+  validatorDir: "../go-tableland",
+  registryDir: "../evm-tableland",
+  verbose: false,
+  silent: false,
+};
+```
+
+If you'd like to override these, such as working with a different Tableland validator or silencing logged outputs, you can update these values accordingly. For most use cases, this is not necessary.
+
+## Docker
+
+Under the hood, the Validator behaves a little differently when using Docker. The path structure changes slightly as compared to the default usage. If you'd like to use Local Tableland on a Docker image, simply pass the flag:
+
+```bash
+npx local-tableland --docker
+```
+
+## Validator overrides
+
+Instead of setting paths in the config file, the `--validator` flag allows you to override the default path to a [`go-tableland`](https://github.com/tablelandnetwork/go-tableland) directory, which is the source code for a Tableland validator node. Recall the default path is `../go-tableland`. If you'd like to, for example, point to some other location where this repo exists, it might look like the following:
+
+```bash
+npx local-tableland --validator /path/to/go-tableland
+```
+
+## Registry overrides
+
+### Path
+
+The `--registry` flag lets you to override the default path to a [`go-tableland`](https://github.com/tablelandnetwork/go-tableland) directory, which is the source code for the Tableland registry smart contract. The default path is `../evm-tableland`. To point to some other location where this repo exists, it might look like the following:
+
+```bash
+npx local-tableland --registry /path/to/evm-tableland
+```
+
+### Port
+
+You can set a custom Registry port for hardhat via the `--registryPort` flag; the default port is 8545. To set a custom port, it might look like the following, which would then use the RPC URL `http://127.0.0.1:9999` instead of the default. This is useful in scenarios where port 8545 is already in use.
+
+```bash
+npx local-tableland --registryPort 9999
+```
+
+A word of caution. When you'd like to make any on-chain actions (sending transactions, reading from contracts), this means the commonly used `http://127.0.0.1:8545` must be replaced with `http://127.0.0.1:9999`. Some clients automatically look for 8545 with a local network, so it's something to keep an eye for and make sure you pass the new, custom URL.

--- a/docs/local-tableland/testing.md
+++ b/docs/local-tableland/testing.md
@@ -1,0 +1,86 @@
+---
+title: Running tests
+description: Use a sandboxed Tableland network in your test suite.
+keywords:
+  - mocha
+  - testing
+  - local tableland
+---
+
+You can run a local Tableland network in your test suite to test your application's integration with Tableland. This is useful for testing its behavior in a sandboxed environment without having to deploy to a public testnet.
+
+## Installation
+
+First, make sure you've installed the package:
+
+```bash npm2yarn
+npm install --save-dev @tableland/local@latest
+```
+
+You are free to use whatever test suite you'd like, but we'll be using [mocha](https://mochajs.org/) for this walkthrough. Make sure it is installed:
+
+```bash npm2yarn
+npm install --save-dev mocha
+```
+
+## Usage
+
+You'll want to create two files: one for setting up the Tableland network, and one for running your tests. Let's assume you have a `test` folder that exists. You should create a `setup.js` file and, for example, a `unit.js` file.
+
+In the setup file, we'll configure the Tableland network by importing `LocalTableland`, instantiating it, and then setting up `before` and `after` hooks for cleanup purposes. These will run once, each.
+
+```js title="test/setup.js"
+import { after, before } from "mocha";
+import { LocalTableland } from "@tableland/local";
+
+const lt = new LocalTableland({ silent: false });
+
+before(async function () {
+  this.timeout(30000);
+  lt.start();
+  await lt.isReady();
+});
+
+after(async function () {
+  await lt.shutdown();
+});
+```
+
+Recall the Tableland network works in two parts: a Registry contract that emits SQL events, and a Validator node that materializes the SQL. When you instantiate `LocalTableland`, it will automatically start both of these components. The `isReady` method will wait until these nodes have properly started, and the `this.timeout(30000)` ensures the tests don't exit early while waiting for these processes to begin (e.g., this is a 30 second timeout).
+
+Now, let's set up a unit test. We'll import `equal` from node's `assert`, mocha helpers, and some helpers for Local Tableland. We'll also make use of the Tableland SDK in this example, but its usage will come from a helper method that comes with `@tableland/local`.
+
+We'll use the second account from the `getAccounts` helper. This is important to note because the first account is specifically used during the Registry contract's deployment process, so it's always a bit safer to start with a fresh account. We'll connect this account to a new Tableland SDK `Database` instance—this is provided to you using the `getDatabase` helper.
+
+```js title="test/unit.js"
+import { match } from "assert";
+import { describe, test } from "mocha";
+import { getAccounts, getDatabase } from "@tableland/local";
+
+describe("unit", function () {
+  this.timeout(10000);
+
+  const accounts = getAccounts();
+  const db = getDatabase(accounts[1]);
+
+  test("passes when a table is created", async function () {
+    const prefix = "test";
+    const { meta } = await db.prepare(`CREATE TABLE ${prefix} (a int);`).run();
+    const tableName = meta.txn?.name ?? "";
+    // We're using `chainId` 31337, and tables have the format `{prefix}_{chainId}_{tableId}`
+    match(tableName, /test_31337_/);
+  });
+});
+```
+
+Note that we also use a timeout of 10 seconds here. You can adjust this based on your needs, but keep in mind that a transaction must first settle on the hardhat node before the Tableland validator processes it. This can take a few seconds end-to-end.
+
+Finally, we'll add a `test` script to our `package.json` file:
+
+```json title="package.json"
+{
+  "scripts": {
+    "test": "mocha"
+  }
+}
+```

--- a/docs/quickstarts/cli-quickstart.md
+++ b/docs/quickstarts/cli-quickstart.md
@@ -31,6 +31,13 @@ Choose to define an optional prefix, such as `quickstart`. If you didn’t run t
 tableland create "id int primary key, val text" --prefix "quickstart" --chain "80001" --privateKey "your_private_key"
 ```
 
+Or, you can choose to pass a full CREATE TABLE statement without the prefix flag:
+
+```bash
+# Create a table & save its returned `name` locally
+tableland create "CREATE TABLE (id int primary key, val text)" --chain "80001" --privateKey "your_private_key"
+```
+
 ## 4. Write and read data
 
 Insert (`write`) a value, and `read` from the newly updated table.

--- a/docs/quickstarts/local-tableland.md
+++ b/docs/quickstarts/local-tableland.md
@@ -25,7 +25,7 @@ npx local-tableland
 
 Under the hood, a few things will then happen:
 
-1. A local [Hardhat](https://hardhat.org/) node is spun up (at `http://localhost:8545`), along with 20 test accounts (public-private keypairs). Note the `chainId` is `31337` for the local blockchain.
+1. A local [Hardhat](https://hardhat.org/) node is spun up (at `http://localhost:8545`), along with 20 test accounts (public-private key pairs). Note the `chainId` is `31337` for the local blockchain.
 2. The `TablelandTables.sol` contract is deployed on the local network, allowing for smart contract calls for table creates and writes.
 3. A local Tableland network node is spun up, which will process the events from the `TablelandTables.sol` contract, materializes the SQL instructions, and allows for read queries locally (via REST API at `http://localhost:8080`).
 
@@ -114,110 +114,6 @@ For example, with the **_second_** account created, import the private key value
 - Public key: `0x70997970C51812dc3A010C7d01b50e0d17dc79C8`
 - Private key: `0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d`
 
-### Nonce too high
-
-If, for some reason, "nonce" errors do occur, such as the "Nonce too high" warning, which might look like the snippet below. Basically, if you were interacting with a local node, the nonce gets tracked for each on-chain action. When you stop the node, that history is maintained such that a new node session is using old nonce tracking. The new node session wants the nonce to start at `0`, but old history says the nonce starts at some other number.
-
-```json
-MetaMask - RPC Error: [ethjs-query] while formatting outputs from RPC '
-{
-  "value": {
-    "code":-32603,
-      "data": {
-        "code":-32000,
-          "message":"Nonce too high. Expected nonce to be 0 but got 50. Note that transactions can't be queued when automining.",
-        "data":{
-          "message":"Nonce too high. Expected nonce to be 0 but got 7. Note that transactions can't be queued when automining."
-      }
-    }
-  }
-}
-```
-
-There are a few resolution paths:
-
-1. If you’re using MetaMask, you can try to reset the transaction history by going to _Settings_ → _Advanced_ → _Reset Account_.
-
-import WalletReset from "@site/static/assets/metamask-reset.png"
-
-<img src={WalletReset} width='30%' />
-
-1.  Resetting your account will clear your transaction history. This will not change the balances in your accounts or require you to re-enter your Secret Recovery Phrase.
-2.  Again, this should only be done if you’re using some test account provided by hardhat.
-
-3.  Enable a "custom nonce" to manually set the nonce upon sending a transaction. Go to _Settings_ → _Advanced_ → _Customize transaction nonce_.
-4.  Delete the wallet and re-import it using the private key—be sure to \***\*only\*\*** delete and reimport the wallet if you do know the private key, or the account could be lost forever.
-
-## Logging & startup
-
-Starting `local-tableland` will provide logging for both the local hardhat blockchain and the local Tableland network. Note there are optional flags for silencing the logs or making them verbose:
-
-```bash
-npx local-tableland --silent
-## Or
-npx local-tableland --verbose
-```
-
-If no flags are passed, the default logging will resemble the following:
-
-```bash
-[Registry] Started HTTP and WebSocket JSON-RPC server at http://127.0.0.1:8545/
-[Registry]
-[Registry]
-[Registry] Accounts
-[Registry] ========
----
-[Registry] eth_sendTransaction
-[Registry] Contract deployment: TablelandTables
-[Registry] Contract address:    0x5fbdb2315678afecb367f032d93f642f64180aa3
----
-[Validator] 8:26PM INF state hash block_number=6 chain_id=31337 component=eventprocessor elapsed_time=5 goversion=go1.19.1 hash=edde6a99dd8d30efb48f8a60de13f53b84a6c6f1 severity=Info version=7144099
-[Validator]
-[Validator] 8:26PM DBG executing create-table event chain_id=31337 component=txnscope goversion=go1.19.1 owner=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 severity=Debug statement="create table healthbot_31337 (counter integer);" token_id=1 txn_hash=0x8459cc42f646c40233966c3ff366f16a4b6678045f23536c3a1839e459a8cd05 version=7144099
-```
-
-First, you’ll notice that each line is prefixed with either `[Registry]` or `[Validator]`, plus the local time at which the log occurred. The **Registry** logs are standard _hardhat node_ interactions. For example, when the `TablelandTables` contract is deployed, it shows up on a line with `[Registry]` and includes information passed by hardhat; the same information available with `npx hardhat node`.
-
-For lines prefixed with **Validator**, these are corresponding to the local _Tableland validator node._ Thus, a line like `[Validator] 8:26PM DBG executing create-table event ...` is an action executed by the local Tableland network node. In this case, it’s relating to a create table statement that was made, but for any table creation, mutation, or read, there will be a corresponding log with the `[Validator]` prefix.
-
-### Additional context
-
-Any time you start `local-tableland`, you’ll notice the same series of events that occur after the _Tableland is running!_ message:
-
-```bash
-******  Tableland is running!  ******
-             _________
-         ___/         \
-        /              \
-       /                \
-______/                  \______
-
-[Validator] 8:26PM INF state hash block_number=6 chain_id=31337 component=eventprocessor elapsed_time=5 goversion=go1.19.1 hash=edde6a99dd8d30efb48f8a60de13f53b84a6c6f1 severity=Info version=7144099
-[Validator]
-[Validator] 8:26PM DBG executing create-table event chain_id=31337 component=txnscope goversion=go1.19.1 owner=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 severity=Debug statement="create table healthbot_31337 (counter integer);" token_id=1 txn_hash=0x8459cc42f646c40233966c3ff366f16a4b6678045f23536c3a1839e459a8cd05 version=7144099
-[Validator]
-[Validator] 8:26PM DBG call ValidateCreateTable goversion=go1.19.1 query="create table healthbot_31337 (counter integer);" severity=Debug version=7144099
-[Validator]
-[Validator] 8:26PM DBG saved receipts chain_id=31337 component=eventprocessor goversion=go1.19.1 height=6 receipts=1 severity=Debug version=7144099
-[Validator]
-[Validator] 8:26PM DBG executing run-sql event chain_id=31337 component=txnscope goversion=go1.19.1 severity=Debug statement="insert into healthbot_31337_1 values (1);" txn_hash=0x0fccfecb3b7a692d2cb4fbb8a79c069a63d0351e1fa32dc00a3e8011b0880835 version=7144099
-[Validator]
-[Validator] 8:26PM DBG call ValidateMutatingQuery goversion=go1.19.1 query="insert into healthbot_31337_1 values (1);" severity=Debug version=7144099
-[Validator]
-[Validator] 8:26PM DBG saved receipts chain_id=31337 component=eventprocessor goversion=go1.19.1 height=7 receipts=1 severity=Debug version=7144099
-[Validator]
-```
-
-The _Validator_ events preceding _Tableland is running!_ are related to the node starting up:
-
-- Database (SQLite) is instantiated.
-- The node "owner" account is set to the 0th wallet provided by hardhat (`0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266`).
-- Various daemons and event trackers are set up.
-
-Then, the first table on the network — the `healthbot` table, consisting of a incrementing `counter` column — is created. Every testnet and mainnet chain that Tableland launches on actually follows the general logic in which this table is created as the first table on the new network. The following describes the steps that happen from this point onward:
-
-- With `executing create-table event ...`, you’ll notice this event comes along with the actual statement (`create table healthbot_31337 (counter integer)`) the table’s `owner`, and the transaction hash at which it was created (`txn_hash`).
-- The following line validates the create statement is valid (`ValidateCreateTable`) and saves the receipt of this create table event / transaction occurring.
-- From there, a `run-sql` event is processed due to the mutating query that is being sent with `insert into healthbot_31337_1 values (1)` (which also comes with a `txn_hash`).
-- The mutating query is validated (`ValidateMutatingQuery`) to ensure SQL compliance as well as the send of the query (who is the `owner`, in this case) has the process access.
-- Lastly, the table mutation is made, and the associated receipt is saved by the node; from there, the local Tableland network is ready to process new tables and queries!
+:::tip
+For more information, dive into the [Local Tableland](/local-tableland) documentation.
+:::

--- a/docs/smart-contracts/serving-nft-metadata.md
+++ b/docs/smart-contracts/serving-nft-metadata.md
@@ -11,7 +11,7 @@ keywords:
 Now that you have data stored as tables, you’ll need to serve it as metadata JSON so that marketplaces, wallets, and platforms can all pick it up for display. In short, you want to take a URL like this one:
 
 ```markdown
-https://testnets.tableland.network/query?unwrap=true&extract=true&s=SELECT json_object('id', '#' || id, 'image', image, 'image_alpha', image_alpha, 'thumb', thumb, 'thumb_alpha', thumb_alpha) FROM rigs_5_13 WHERE id=1
+https://testnets.tableland.network/query?unwrap=true&extract=true&statement=SELECT json_object('id', '#' || id, 'image', image, 'image_alpha', image_alpha, 'thumb', thumb, 'thumb_alpha', thumb_alpha) FROM rigs_5_13 WHERE id=1
 ```
 
 ...which returns:
@@ -50,7 +50,7 @@ import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 
 contract Example {
   // The testnet gateway URI plus query parameter
-  string private _baseURIString = "https://testnets.tableland.network/query?unwrap=true&extract=true&s=";
+  string private _baseURIString = "https://testnets.tableland.network/query?unwrap=true&extract=true&statement=";
 
   // The base URI used by tokenURI
   function _baseURI() internal view override returns (string memory) {
@@ -63,7 +63,7 @@ By default, the `tokenURI()` method will take this URI and append the requested 
 
 ```tsx
 tokenURI(1) { return _baseURIString + '/' + 1 }
-// https://testnets.tableland.network/query?unwrap=true&extract=true&s=/1
+// https://testnets.tableland.network/query?unwrap=true&extract=true&statement=/1
 ```
 
 For most uses of Tableland, we’ll want to modify this so that SQL can be used to extract the correct metadata for a specific token.
@@ -124,7 +124,7 @@ import "@tableland/evm/contracts/utils/URITemplate.sol";
 
 contract Example {
   // The testnet gateway URI plus query parameter
-  string private _baseURIString = "https://testnets.tableland.network/query?unwrap=true&extract=true&s=";
+  string private _baseURIString = "https://testnets.tableland.network/query?unwrap=true&extract=true&statement=";
 
   constructor() {
     string private uriTemplate = "SELECT+json_object%28%27id%27%2C+id%2C+%27name%27%2C+name%2C+%27color%27%2C+color%29+FROM+tokenuri_table_1+WHERE+id%3D{id}"

--- a/docs/smart-contracts/uri-encoding.md
+++ b/docs/smart-contracts/uri-encoding.md
@@ -93,14 +93,14 @@ If you opt to create the URI and write it with Solidity, one helpful library for
 function tokenURI(string memory _tableName) public view returns (string memory) {
 	string memory base = _baseURI();
 	// Here, the baseURI is:
-	// https://testnets.tableland.network/api/v1/query?unwrap=true&extract=true&s=
+	// https://testnets.tableland.network/api/v1/query?unwrap=true&extract=true&statement=
   return string.concat(
     base,
     "SELECT%20%2A%20FROM%20",
     _tableName
   );
 	// Thus, the full string is:
-	// https://testnets.tableland.network/api/v1/query?unwrap=true&extract=true&s=SELECT%20%2A%20FROM%20<table_name_param>
+	// https://testnets.tableland.network/api/v1/query?unwrap=true&extract=true&statement=SELECT%20%2A%20FROM%20<table_name_param>
 }
 ```
 

--- a/docs/tutorials/table-reads-chainlink.md
+++ b/docs/tutorials/table-reads-chainlink.md
@@ -11,7 +11,7 @@ The following walks through how to query off-chain table state and write it back
 
 ## Synopsis
 
-We’ll be using the Chainlink [Any API](https://docs.chain.link/getting-started/advanced-tutorial/) to read data from the Tableland network and write it back on-chain. It will use the "single word response" [GET method](https://docs.chain.link/any-api/get-request/examples/single-word-response/) to retrieve a single unsigned integer value from Tableland ([here](https://testnets.tableland.network/query?unwrap=true&s=select%20%2A%20from%20healthbot_11155111_1)) and write it back on-chain.
+We’ll be using the Chainlink [Any API](https://docs.chain.link/getting-started/advanced-tutorial/) to read data from the Tableland network and write it back on-chain. It will use the "single word response" [GET method](https://docs.chain.link/any-api/get-request/examples/single-word-response/) to retrieve a single unsigned integer value from Tableland ([here](https://testnets.tableland.network/query?unwrap=true&statement=select%20%2A%20from%20healthbot_11155111_1)) and write it back on-chain.
 
 Recall that writing data to Tableland happens with on-chain actions, whereas reading \***\*from\*\*** the Tableland network occurs via an off-chain gateway query. If a developer wants to query for data and make some on-chain action based on the result, they’ll need to use an oracle to retrieve the data.
 
@@ -96,7 +96,7 @@ constructor() ConfirmedOwner(msg.sender) {
 
 The following URL will be used for requesting Tableland state on-chain:
 
-- _[https://testnets.tableland.network/query?unwrap=true&s=select%20%2A%20from%20healthbot_421613_1](https://testnets.tableland.network/query?unwrap=true&s=select%20%2A%20from%20healthbot_421613_1)_
+- _[https://testnets.tableland.network/query?unwrap=true&statement=select%20%2A%20from%20healthbot_421613_1](https://testnets.tableland.network/query?unwrap=true&statement=select%20%2A%20from%20healthbot_421613_1)_
 
 It is the Tableland `healthbot` table deployed on the Arbitrum Goerli testnet, which simply increments a single `counter` key by an integer value. For mainnet chains, be sure to use the `tableland.network` gateway over the `testnets.tableland.network` gateway.
 
@@ -368,7 +368,7 @@ contract TableState is ChainlinkClient, ConfirmedOwner {
 
 To see the full deployment code, check out the [repo](https://github.com/dtbuchholz/tutorial-on-chain-reads-chainlink-arbitrum). Here, we’ll highlight some actions that should take place from within a deploy script:
 
-- Set the `url` value, using `setRequestUrl`, to the Tableland gateway at [https://testnets.tableland.network/query?unwrap=true&s=select%20%2A%20from%20healthbot_421613_1](https://testnets.tableland.network/query?unwrap=true&s=select%20%2A%20from%20healthbot_421613_1)
+- Set the `url` value, using `setRequestUrl`, to the Tableland gateway at [https://testnets.tableland.network/query?unwrap=true&statement=select%20%2A%20from%20healthbot_421613_1](https://testnets.tableland.network/query?unwrap=true&statement=select%20%2A%20from%20healthbot_421613_1)
 - Set the `path` value, using `setRequestPath`, to `counter`
 - Fund the contract with `LINK`.
 

--- a/docs/validator/README.md
+++ b/docs/validator/README.md
@@ -1,6 +1,6 @@
 ---
 title: Validator node
-description: Learn how to run you own Tableland validator node.
+description: Learn how to run your own Tableland validator node.
 keywords:
   - validator
 ---

--- a/docs/validator/README.md
+++ b/docs/validator/README.md
@@ -1,0 +1,469 @@
+---
+title: Validator node
+description: Learn how to run you own Tableland validator node.
+keywords:
+  - validator
+---
+
+Tableland is a permissionless network where anyone can run and operate their own node. This page walks through how to run your own node, including hardware requirements, installation steps, and common questions.
+
+<!-- Imported from https://github.com/tablelandnetwork/go-tableland/blob/main/README.md -->
+
+## Background
+
+`go-tableland` is a Go language implementation of a Tableland node, enabling developers and service providers to run nodes on the Tableland network and host databases for web3 users and applications. Note that the Tableland protocol is currently in open beta, so node operators have the opportunity to be one of the early network adopters while the responsibilities of the validator will continue to change as the Tableland protocol evolves.
+
+### What is a validator?
+
+Validators are the execution unit/actors of the protocol.
+
+They have the following responsibilities:
+
+- Listen to on-chain events to materialize Tableland-compliant SQL queries in a database engine (currently, SQLite by default).
+- Serve read-queries (e.g., `SELECT * FROM foo_69_1`) to the external world.
+
+:::tip
+In the future, validators will have more responsibilities in the network.
+:::
+
+### Validator and network relationship
+
+The following diagram describes a high level interaction between the validator, EVM chains, and the external world:
+
+<p align="center">
+  <img src="https://user-images.githubusercontent.com/13358940/249310798-a65732b9-a48b-4547-bc4d-71af8bd4e09f.png" width='80%'/>
+</p>
+
+To better understand the usual mechanics of the validator, let’s go through a typical use case where a user mints a table, adds data to the table, and reads from it:
+
+1. The user will mint a table (ERC721) from the Tableland `Registry` smart contract on a supported EVM chain.
+2. The `Registry` contract will emit a `CreateTable` event containing the `CREATE TABLE` statement as extra data.
+3. Validators will detect the new event and execute the `CREATE TABLE` statement.
+4. The user will call the `mutate` method in the `Registry` smart contract, with mutating statements such as `INSERT INTO ...`, `UPDATE ...`, `DELETE FROM ...`, etc.
+5. The `Registry` contract, as a result of that call, will emit a `RunSQL` event that contains the mutating SQL statement as extra data.
+6. The validators will detect the new event and execute the mutating query in the corresponding table, assuming the user has the right permissions (e.g., table ownership and/or smart contract defined access controls).
+7. The user can query the `/query?statement=...` REST endpoint of the validator to execute read-queries (e.g., `SELECT * FROM ...`), to see the materialized result of its interaction with the smart contract.
+
+:::tip
+The description above is optimized to understand the general mechanics of the validator. Minting tables and executing mutating statements also imply more work both at the smart contract and validator levels (e.g., ACL enforcing), which are being omitted here for simplicity sake.
+:::
+
+The validator detects the smart contract events using an EVM node API (e.g., `geth` node), which can be self-hosted or served by providers (e.g., Alchemy, Infura, etc).
+
+If you're curious about Tableland network growth, eager to contribute, or interested in experimenting, we encourage you to try running a validator. To get started, follow the step-by-step instructions provided below. We appreciate your interest and welcome any questions or feedback you may have during the process; stay tuned for updates and developments in our [Discord](https://tableland.xyz/discord) and [Twitter](https://twitter.com/tableland).
+
+For projects that want to _use_ the validator API, Tableland [maintains a public gateway](https://docs.tableland.xyz/gateway-api) that can be used to query the network.
+
+### Running a validator
+
+Running a validator only involves running a single process. Since we use SQLite as the default database engine, it is embedded and has many advantages:
+
+- There’s no separate process for the database.
+- There’s no inter-process communication between the validator and the database.
+- There’s no separate configuration or monitoring needed for the database.
+
+We provide everything you need to run a validator with a single command using a docker-compose setup. This will automatically build everything from the source code, making it platform-independent since most OSes support docker. The build process is also dockerized, so node operators don’t need to worry about installing compilers or similar.
+
+If you like creating your own setup (e.g., run raw binaries, use systemd, k8, etc.), we’re also planning to automate versioned Docker images or compiled executables. If there are other setups you're interested in, feel free to let us know or even share your own setup.
+
+The [Docker Compose setup](#docker-compose-setup) section below describes how to run a validator in more detail, including:
+
+- Folder structure.
+- Configuration files.
+- Where the state of the validator lives.
+- Baked in observability stack (i.e., Prometheus + Grafana with dashboard).
+- Optional `healthbot` process to have an end-to-end (e2e) healthiness check of the validator.
+
+Reviewing this section is _strongly_ recommended but not strictly necessary.
+
+## Usage
+
+### System requirements
+
+Currently, we recommend running the validator on a machine that has at least:
+
+- 4 vCPUs.
+- 8GiB of RAM.
+- SSD disk with 10GiB of free space.
+- Reliable and fast internet connection.
+- Static IP.
+
+Hardware requirements might change with time, but this setup is probably over provisioned in the current state. We’re planning to do a stress testing benchmark suite to understand and predict the behavior of the validator under different loads to have more data about potential future recommended system requirements.
+
+### Firewall configuration
+
+If you’re behind a firewall, you should open ports `:8080` or `:443`, depending on if you run with TLS certificates. By default, TLS is not required, thus, expecting `:8080` to be open to the external world.
+
+### System prerequisites
+
+There are two prerequisites for running a validator:
+
+- Install host-level dependencies.
+- Get EVM node API keys.
+
+Tableland has two separate networks:
+
+- `mainnet`: this network syncs mainnet EVM chains (e.g., Ethereum mainnet, Arbitrum mainnet, etc.).
+- `testnet`: this network is syncing testnet EVM chains (e.g., Ethereum Sepolia, Arbitrum Goerli, etc.).
+
+This guide will focus on running the validator in the `mainnet` network.
+
+We do this for two reasons:
+
+- The `mainnet` network is the most stable one and is also where we want the most number of validators.
+- We can provide concrete file paths related to `mainnet` and avoid being abstract.
+
+We’ll also explain how to run a validator using Alchemy as a provider for the EVM node API the validator will use. The configuration will be analogous if you use self-hosted nodes or other providers. Note that if you _do_ want to support testnets, you can, generally, replace this documentation's `mainnet` reference with `testnet` (e.g., an environment variable with `MAINNET` would be `TESTNET`; `docker/deployed/mainnet` would shift to `docker/deployed/testnet`).
+
+#### Install host-level dependencies
+
+To run the provided docker-compose setup, you’ll need to have installed:
+
+- `git`: [Installation guide](https://github.com/git-guides/install-git).
+- `docker` with the Compose plugin: [The default Docker engine installation](https://docs.docker.com/engine/install/) already includes the Compose plugin (i.e., `docker compose` command).
+
+Note that there’s no need for a particular `Go` installation since binaries are compiled within a docker container containing the correct Go compiler versions. Despite not being strictly necessary, creating a separate user in the host is usually recommended to run the validator.
+
+#### Create EVM node API keys
+
+The current setup needs one API key per supported chain. The default setup expects Alchemy keys for the following: Ethereum, Optimism, Arbitrum One, and Polygon; QuickNode for Arbitrum Nova. But, you are free to use a self-hosted node or another provider that supports the targeted chains.
+
+To get your Alchemy keys, create an [Alchemy](https://alchemy.com) account, log in, and follow these steps:
+
+1. Create one app for each chain using the `+ Create App` button.
+2. You’ll see one row per chain—click the `View Key` button and copy/save the `API KEY`.
+
+To get your QuickNode Arbitrum Nova key, create a [QuickNode](https://quicknode.com) account, log in, and follow these steps:
+
+1. Create an endpoint.
+2. Select Arbitrum Nova Mainnet.
+3. When you finish the wizard, you should be able to have access to your API key.
+
+:::tip
+Note: For Filecoin, we recommend [Glif.io](https://api.calibration.node.glif.io/rpc/v1) RPC support, which does not require authentication; the `.env` variable's value (shown below) can be left empty.
+:::
+
+### Run the validator
+
+Now that you have installed the host-level dependencies, have one wallet per chain, and provider (Alchemy, QuickNode, etc.) API keys, you’re ready to configure the validator and run it.
+
+#### 1. Clone the `go-tableland` repository
+
+Navigate to the folder where you want to clone the repository and run:
+
+```sh
+git clone https://github.com/tablelandnetwork/go-tableland.git
+```
+
+:::tip
+Running the `main` branch should always be safe since it’s the exact code that the public validator is running. We recommend this approach since we’re moving quickly with features and improvements but expect soon to be better guided by official releases.
+:::
+
+#### 2. Configure your secrets in `.env` files
+
+You must configure each EVM account's private keys and EVM node provider API keys into the validator secrets:
+
+1. Create a `.env_validator` file in `docker/deployed/mainnet/api` folder—an example is provided with `.env_validator.example`.
+2. Add the following to `.env_validator` (as noted, this focuses on mainnet configurations but could be generally replicated for testnet support):
+
+   ```txt
+   VALIDATOR_ALCHEMY_ETHEREUM_MAINNET_API_KEY=<your ethereum mainnet alchemy key>
+   VALIDATOR_ALCHEMY_OPTIMISM_MAINNET_API_KEY=<your optimism mainnet alchemy key>
+   VALIDATOR_ALCHEMY_ARBITRUM_MAINNET_API_KEY=<your arbitrum mainnet alchemy key>
+   VALIDATOR_ALCHEMY_POLYGON_MAINNET_API_KEY=<your polygon mainnet alchemy key>
+   VALIDATOR_QUICKNODE_ARBITRUM_NOVA_MAINNET_API_KEY=<your arbitrum nova mainnet quicknode key>
+   VALIDATOR_GLIF_FILECOIN_MAINNET_API_KEY=
+   ```
+
+   > Note: there is also an optional `METRICS_HUB_API_KEY` variable; this can be left empty. It's a service (`cmd/metricshub`) that aggregates metrics like `git summary` and pushes them to centralized infrastructure ([GCP Cloud Run](https://cloud.google.com/run)) managed by the core team. If you'd like to have your validator push metrics to this hub, please reach out to the Tableland team, and we may make it available to you. However, this process will further be decentralized in the future and remove this dependency entirely.
+
+3. Tune the `docker/deployed/mainnet/api/config.json` :
+
+   1. Change the `ExternalURIPrefix` configuration attribute into the DNS (or IP) where your validator will be serving external requests.
+   2. In the `Chains` section, only leave the chains you’ll be running; remove any chain entries you do not wish to support.
+
+      <details> 
+        <summary>Reference: example entry</summary>
+
+      ```json
+      {
+        "Name": "Ethereum Mainnet",
+        "ChainID": 1,
+        "Registry": {
+          "EthEndpoint": "wss://eth-mainnet.g.alchemy.com/v2/${VALIDATOR_ALCHEMY_ETHEREUM_MAINNET_API_KEY}",
+          "ContractAddress": "0x012969f7e3439a9B04025b5a049EB9BAD82A8C12"
+        },
+        "EventFeed": {
+          "ChainAPIBackoff": "15s",
+          "NewBlockPollFreq": "10s",
+          "MinBlockDepth": 1,
+          "PersistEvents": true
+        },
+        "EventProcessor": {
+          "BlockFailedExecutionBackoff": "10s",
+          "DedupExecutedTxns": true,
+          "WebhookURL": "https://discord.com/api/webhooks/${VALIDATOR_DISCORD_WEBHOOK_ID}/${VALIDATOR_DISCORD_WEBHOOK_TOKEN}"
+        },
+        "HashCalculationStep": 150
+      }
+      ```
+
+      </details>
+
+4. Create a `.env_grafana` file in the `docker/deployed/mainnet/grafana` folder—an example is provided with `.env_grafana.example`.
+5. Add the following to `.env_grafana`:
+
+```txt
+GF_SECURITY_ADMIN_USER=<user name you'd like to login intro grafana>
+GF_SECURITY_ADMIN_PASSWORD=<password of the user>
+```
+
+:::tip
+Note: the `GF_SERVER_ROOT_URL` variable is optional and can be left empty. By default, Grafana is hosted locally at `http://localhost:3000`.
+:::
+
+That’s it...your validator is now configured!
+
+It's worthwhile to review the `config.json` file to see how the environment variables configured in the `.env` files inject these secrets into the validator configuration. Also, note how supporting more chains only requires adding an extra entry in the `Chains`, so it's straightforward to add support for any of the supported `testnets` of each `mainnet` chain. Note that adding a _new_ `mainnet` chain that's not yet supported by the network is not possible as this requires the core Tableland protocol to separately deploy a `Registry` smart contract in order to enable new chain support. This is performed on a case-by-case basis, so please reach out to the Tableland team if you'd like support for a new `mainnet` chain.
+
+#### 3. Run the validator
+
+To run the validator, move to the `docker` folder and run the following:
+
+```sh
+make mainnet-up
+```
+
+Some general comments and tips:
+
+- The first time you run this, it can take some time since you’ll have a cold cache regarding images and dependencies in Docker; subsequent runs will be quite fast.
+- You can inspect the general health of containers with `docker ps`.
+- You can tail the logs with `docker logs docker-api-1 -f`.
+- You can tear down the stack with `make mainnet-down`.
+
+:::tip
+The default docker-compose setup has a baked-in observability substack with Prometheus and Grafana. You can learn more about this in the next section.
+:::
+
+While the validator is syncing, you might see the logs are generated rather quickly. In the `docker/deployed/mainnet/api/database.db`, you should expect that the SQLite database will start to grow in size.
+
+### Docker Compose setup
+
+The docker-compose setup can feel a bit magical, so in this section, we’ll explain the setup's folder structure and important considerations. Remember that you don’t need to understand this section to run a validator, but knowing how things work is highly recommended.
+
+#### Architecture and port bindings
+
+When you run `make mainnet-up`, you’re running the following stack:
+
+<p align="center">
+  <img src="https://user-images.githubusercontent.com/13358940/249326369-b94c12b9-6550-49c9-92b3-5e662c8bcd72.png" width='80%'/>
+</p>
+
+If you’re running the validator, you’ll see these four containers running with `docker ps`.
+
+There’re two main port binding groups:
+
+- `:8080` and `:443` to the `api` container (the validator), depending if you have configured TLS in the validator.
+- `:3000` to the `grafana` container to access the Grafana dashboard. Remember that if you want to access to Grafana from the external world, you’ll have to configure your firewall.
+
+Regarding the containers:
+
+- `api` is the container running the validator.
+- `healthbot` is an optional container to have an e2e daemon checking the healthiness of the full write-query transaction and events execution. More about this in the [Healthbot section](https://www.notion.so/Validator-documentation-9f0cc2abf424410c8659fa939ed5095e?pvs=21).
+- `grafana` and `prometheus` are part of the observability stack, allowing a fully-featured Grafana dashboard that provides useful live information about the validator. There's more information about this in the [Observability section](#observability-stack).
+
+#### Folder structure
+
+The `docker/deployed/mainnet` folder contains one folder per process that it’s running:
+
+- `api` folder: contains all the relevant secrets, configuration and state of the validator.
+  - `config.json` file: the full configuration file of the validator.
+  - `.env_validator` file: contains secrets that are injected in the `config.json` file.
+  - `database.db*` files: when you run the validator, you’ll see these files, which are the SQLite database of the validator (running in [WAL](https://www.sqlite.org/wal.html) mode).
+- `grafana` and `prometheus` folders: contain any state from these daemons. For example, Grafana can include alerts or settings customizations, and Prometheus has the time-series database, so whenever you reset the container, it will keep historical data.
+- `healthbot` folder: contains secrets and configuration for the healthbot.
+
+From an operational point of view, you usually don’t have to touch these folders apart from the `api/config.json` or `api/.env_validator` if you want to change something about the validator configuration or secrets. The Prometheus setup has a default 15 days retention time for the time series data, so the database size should be automatically bounded.
+
+#### Configuration files
+
+The validator configuration is done via a JSON file located at `deployed/mainnet/api/config.json`.
+
+This file contains general and chain-specific configuration, such as desired listening ports, gateway configuration, log level configuration, and chain-specific configuration, including name, chain ID, contract address, wallet private keys, and EVM node API endpoints.
+
+The provided configurations in each `deployed/<environment>` already have everything needed for the environment and other recommended values. The environment variable expansion parts of the `config.json` file, such as secrets and other attributes in the `.env_validator` file, were explained in the [secret configuration section](2-configure-your-secrets-in-env-files) above. For example, the `VALIDATOR_ALCHEMY_ETHEREUM_MAINNET_API_KEY` variable configured in `.env_validator` expands a `${VALIDATOR_ALCHEMY_ETHEREUM_MAINNET_API_KEY}` present in the `config.json` file. If you want to use a self-hosted Ethereum mainnet node API or another provider, you can edit the `config.json` file in the `EthEndpoint` endpoint. This same logic applies to every possible configuration in the validator.
+
+#### Observability stack
+
+As mentioned earlier, the default docker-compose setup provides a fully configured observability stack by running Prometheus and Grafana.
+
+This setup configures the scrape endpoints in Prometheus to pull metrics from the validator and data sources dashboard for Grafana. These automatically bound configuration files are in `docker/observability/(grafana|prometheus)` folders. They are not part of the state of the processes. This is intentional so that, for example, the dashboard is part of the `go-tableland` repository, and you’ll get automatic dashboard upgrades while is being improved or extended.
+
+After you spin up the validator, you can go to `http://localhost:3000` and access the Grafana setup. Recall that you configured the credentials in the `.env_grafana` file in `docker/deployed/mainnet/grafana`.
+
+If you browse the existing dashboards, you should see an existing _Validator_ dashboard that should look like the following, which aggregates all metrics that the validator generates:
+
+<p align="center">
+  <img src="https://user-images.githubusercontent.com/13358940/249328422-3d727309-42b8-4ffc-9f2f-bcfed6b5d398.png" width='80%'/>
+</p>
+
+#### Healthbot (optional)
+
+The `healthbot` daemon is an optional feature of the docker-compose stack and is _only_ needed if you support a testnet network; it's disabled by default.
+
+The main goal of `healthbot` is to test e2e in order to see if the validator is running correctly:
+
+- For every configured chain, it executes a write statement to Tableland smart contract to increase a counter value in a pre-minted table that is owned by the validator.
+- It waits to see if the increased counter in the target table was materialized in the table, thus, signaling that:
+  - The transaction with the `UPDATE` statement was correctly sent to the chain.
+  - The transaction was correctly minted in the target blockchain.
+  - The event for that `UPDATE` was detected and processed by the validator
+  - A `SELECT` statement reading that table should read the increased counter in the target table.
+
+In short, it tests most of the processing healthiness of the validator. For each of the target chains, you should mint a table with the following statement:
+
+```sql
+CREATE TABLE healthbot_{chainID} (counter INTEGER);
+```
+
+This would result in having four tables—one per chain:
+
+- `healthbot_11155111_{tableID}` (Ethereum Sepolia)
+- `healthbot_420_{tableID}` (Optimism Goerli)
+- `healthbot_421613_{tableID}` (Arbitrum Goerli)
+- `healthbot_80001_{tableID}` (Polygon Mumbai)
+- `healthbot_314159_{tableID}` (Filecoin Calibration)
+
+You should create a file `.env_healthbot` in the `docker/deployed/testnet/healthbot` folder with the following content (an example is provided with `.env_healthbot.example`):
+
+```txt
+HEALTHBOT_ETHEREUM_SEPOLIA_TABLE=healthbot_11155111_{tableID}
+HEALTHBOT_OPTIMISM_GOERLI_TABLE=healthbot_420_{tableID}
+HEALTHBOT_ARBITRUM_GOERLI_TABLE=healthbot_421613_{tableID}
+HEALTHBOT_POLYGON_MUMBAI_TABLE=healthbot_80001_{tableID}
+HEALTHBOT_FILECOIN_CALIBRATION_TABLE=healthbot_314159_{tableID}
+```
+
+Finally, edit the `docker/deployed/testnet/healthbot/config.json` file `Target` attribute with the public DNS where your validator is serving to the external world. This is the endpoint where the healthbot will be making the healthiness probes. Since running the `healthbot` requires custom tables to be minted, it’s disabled by default.
+
+To enable running the `healthbot`, you should run the following `make testnet-up` with the `HEALTHBOT_ENABLED=true` environment value set:
+
+```sh
+HEALTHBOT_ENABLED=true make testnet-up
+```
+
+After a few minutes, you should see the `HealthBot -e2e check` section of the Grafana dashboard populated:
+
+<p align="center">
+  <img src="https://user-images.githubusercontent.com/13358940/249330376-53afd85e-693b-47d4-b877-9463a10af135.png" width='80%'/>
+</p>
+
+#### Pruning docker images (optional)
+
+Removing old docker images from time to time may be beneficial to avoid unnecessary disk usage. You can set up a `cron` rule to do that automatically. For example, you could do the following:
+
+1. Run `crontab -e`.
+2. Add the rule: `0 0 * * FRI /usr/bin/docker system prune --volumes -f  >> /home/validator/cronrun 2>&1`
+
+### Backups and other routines
+
+All validators are equipped with a backup scheduler that runs a background routine that executes a backup process of the SQLite database file at a configurable regular frequency. Besides the main backup of the database, the `Backuper` process executes a `VACUUM` process in the backup file and compresses it with `zstd`.
+
+#### How the backup process works
+
+The backup process called `Backuper` takes a backup of `SQLite` database file and stores it in a local directory relative to where the database is stored.
+
+The process uses the [SQLite Backup API](https://www.sqlite.org/c3ref/backup_finish.html) provided by [mattn/go-sqlite3](https://pkg.go.dev/github.com/mattn/go-sqlite3#SQLiteBackup). It is a full backup in a single step. Right now, the database is small enough not to worry about locking and how long it takes, but an incremental backup approach may be needed when as the database grows in the future.
+
+#### How the scheduler works
+
+The scheduler ticks at a regular interval defined by the `Frequency` config. It is important to mention that the time it runs is relative to the epoch time. That means, as the validator becomes operational and healthy after a deployment, it will start a backup routine in the next timestamp multiple of `Frequency` relative to epoch. That allows having backup files evenly distributed according to timestamp.
+
+#### Vacuum
+
+After the backup is finished, it executes the `VACUUM` SQL statement in the backup database to remove any unused rows and reduce the database file. This process may take a while, but it's expected since there shouldn't be any other connections to the backup database at this point.
+
+#### Compression
+
+After **vacuum**, we shrink the database even further by compressing it using the [zstd](http://facebook.github.io/zstd/) algorithm implemented by [compress](https://github.com/klauspost/compress) library.
+
+#### Pruning
+
+We don't keep all backup files around—at the end, we remove any files exceeding the backup's `KeepFiles` config, located in `cmd/api/config.go`. The default value is `5`.
+
+#### Filename convention
+
+The backup files follow the pattern: `tbl_backup_{{TIMESTAMP}}.db.zst`. For example, it should resemble the following: `tbl_backup_2022-08-25T20:00:00Z.db.zst`.
+
+#### Decompressing the file
+
+If you're on Linux or Mac, you should have `unzstd` installed out of the box. For example, run `unzstd tbl_backup_2022-08-25T20:00:00Z.db.zst` (replace with your file name) to decompress the compressed database file.
+
+#### Metrics
+
+We collect the following metrics from the process through **logs**:
+
+```go
+Timestamp.             time.Time
+ElapsedTime            time.Duration
+VacuumElapsedTime      time.Duration
+CompressionElapsedTime time.Duration
+Size                   int64
+SizeAfterVacuum        int64
+SizeAfterCompression   int64
+```
+
+Additionally, we collect the metric `tableland.backup.last_execution` through **Open Telemetry** and **Prometheus**.
+
+#### Configs
+
+The backup configuration files are located in the `docker/deployed/mainnet/api/config.json` file. The following is the default configuration:
+
+```json
+"Backup" : {
+  "Enabled": true,       // enables the backup scheduler to execute backups
+  "Dir": "backups",      // where backup files are stored relative to db
+  "Frequency": 240,      // backup frequency in minutes
+  "EnableVacuum": true,
+  "EnableCompression": true,
+  "Pruning" : {
+    "Enabled": true,  // enables pruning
+    "KeepFiles": 5    // pruning keeps at most `KeepFiles` backup files
+  }
+}
+```
+
+## Development
+
+Get started by following the validator setup steps described above. From there, you can make changes to the codebase and run the validator locally. For a validator stack against a local Hardhat network, you can run the following from the `docker` folder:
+
+- `make local-up`
+- `make local-down`
+
+For a validator stack against deployed staging environments, you can run:
+
+- `make staging-up`
+- `make staging-down`
+
+### Configuration
+
+Note that for deployed environments, there are two relevant configuration files in each folder `docker/deployed/<environment>`:
+
+- `.env_validator`: allows you to configure environments to fill secrets for the validator, plus, expand variables present in the config file (see the `.env_validator.example` example file).
+- `config.json`: the configuration file for the validator.
+
+Besides that, you may want to configure Grafana's `admin_user` and `admin_password`. To do that, configure the `.env_grafana` file with the values of the expected keys shown in `.env_grafana.example`. This all should have been set up already but is worth noting.
+
+## Contributing
+
+PRs accepted. Feel free to get in touch by:
+
+- Opening an issue.
+- Joining our [Discord server](https://tableland.xyz/discord).
+
+Small note: If editing the README, please conform to the
+[standard-readme](https://github.com/RichardLitt/standard-readme) specification.
+
+## License
+
+MIT AND Apache-2.0, © 2021-2023 Tableland Network Contributors

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -77,6 +77,7 @@ async function createConfig() {
             "https://raw.githubusercontent.com/tablelandnetwork/go-tableland/main/", // The base url for the markdown (gets prepended to all of the documents when fetching)
           outDir: "docs/validator", // The base directory to output to
           documents: ["README.md"], // The file names to download
+          performCleanup: false, // Make sure generated file is not deleted on subsequent builds
           modifyContent(filename, content) {
             if (filename.includes("README")) {
               // Remove all content above `## Background`, which includes the
@@ -99,7 +100,7 @@ async function createConfig() {
               return {
                 content: `---
 title: Validator node
-description: Learn how to run you own Tableland validator node.
+description: Learn how to run your own Tableland validator node.
 keywords:
   - validator
 ---


### PR DESCRIPTION
## Summary

Adds more docs for Local Tableland usage and testing, including the custom registry port feature. Also, makes some small docs typo and other fixes. Closes #129, #154.