### PR TITLE
adds post query to the api spec

### DIFF
--- a/specs/validator/README.md
+++ b/specs/validator/README.md
@@ -10,22 +10,17 @@ This general API specification is used to automatically generate clients and bac
 
 ### Table of Contents
 
-- [Synopsis](#synopsis)
-  - [Table of Contents](#table-of-contents)
 - [Query the network](#query-the-network)
+- [Query the network (POST)](#query-the-network-post)
 - [Get transaction status](#get-transaction-status)
 - [Get table information](#get-table-information)
 - [Get health status](#get-health-status)
 - [Get version information](#get-version-information)
-  - [Properties](#properties)
-  - [Properties](#properties-1)
-  - [Properties](#properties-2)
-  - [Properties](#properties-3)
-  - [Properties](#properties-4)
+- [Schemas](#schemas)
 
 <!-- Generator: Widdershins v4.0.1 -->
 <h1 id="tableland-validator-openapi-3-0">
-Tableland Validator - OpenAPI 3.0 v1.0.1
+Tableland Validator - OpenAPI 3.0 v1.1.0
 </h1>
 
 > Scroll down for code samples, example requests and responses. Select a
@@ -35,8 +30,8 @@ Tableland Validator - OpenAPI 3.0 v1.0.1
 In Tableland, Validators are the execution unit/actors of the protocol.
 They have the following responsibilities: - Listen to onchain events to
 materialize Tableland-compliant SQL queries in a database engine
-(currently, SQLite by default). - Serve read-queries (e.g: SELECT \*
-FROM foo_69_1) to the external world. - Serve state queries (e.g. list
+(currently, SQLite by default). - Serve read-queries (e.g., SELECT \*
+FROM foo_69_1) to the external world. - Serve state queries (e.g., list
 tables, get receipts, etc) to the external world.
 
 In the 1.0.0 release of the Tableland Validator API, we’ve switched to a
@@ -44,6 +39,14 @@ design first approach! You can now help us improve the API whether it’s
 by making changes to the definition itself or to the code. That way,
 with time, we can improve the API in general, and expose some of the new
 features in OAS3.
+
+The API includes the following endpoints: - `/health`: Returns OK if the
+validator considers itself healthy. - `/version`: Returns version
+information about the validator daemon. - `/query`: Returns the results
+of a SQL read query against the Tableland network. -
+`/receipt/{chainId}/{transactionHash}`: Returns the status of a given
+transaction receipt by hash. - `/tables/{chainId}/{tableId}`: Returns
+information about a single table, including schema information.
 
 Base URLs:
 
@@ -69,7 +72,7 @@ Query the Tableland network
 
 > Code samples
 
-```shell
+``` shell
 # You can also use wget
 curl -X GET https://testnets.tableland.network/api/v1/query?statement=select%20%2A%20from%20healthbot_80001_1 \
   -H 'Accept: application/json'
@@ -77,14 +80,14 @@ curl -X GET https://testnets.tableland.network/api/v1/query?statement=select%20%
 
 `GET /query`
 
-Returns the results of a SQL read query against the Tabeland network
+Returns the results of a SQL read query against the Tableland network
 
 <h3 id="query-the-network-parameters">
 Parameters
 </h3>
 
 | Name      | In    | Type    | Required | Description                                                                                 |
-| --------- | ----- | ------- | -------- | ------------------------------------------------------------------------------------------- |
+|-----------|-------|---------|----------|---------------------------------------------------------------------------------------------|
 | statement | query | string  | true     | The SQL read query statement                                                                |
 | format    | query | string  | false    | The requested response format:                                                              |
 | extract   | query | boolean | false    | Whether to extract the JSON object from the single property of the surrounding JSON object. |
@@ -99,7 +102,7 @@ query results as a JSON object with columns and rows properties.
 #### Enumerated Values
 
 | Parameter | Value   |
-| --------- | ------- |
+|-----------|---------|
 | format    | objects |
 | format    | table   |
 
@@ -107,7 +110,7 @@ query results as a JSON object with columns and rows properties.
 
 > 200 Response
 
-```json
+``` json
 {}
 ```
 
@@ -116,13 +119,75 @@ Responses
 </h3>
 
 | Status | Meaning                                                            | Description                   | Schema |
-| ------ | ------------------------------------------------------------------ | ----------------------------- | ------ |
+|--------|--------------------------------------------------------------------|-------------------------------|--------|
 | 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)            | Successful operation          | Inline |
 | 400    | [Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)   | Invalid query/statement value | None   |
 | 404    | [Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)     | Row Not Found                 | None   |
 | 429    | [Too Many Requests](https://tools.ietf.org/html/rfc6585#section-4) | Too Many Requests             | None   |
 
 <h3 id="query-the-network-responseschema">
+Response Schema
+</h3>
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## Query the network (POST)
+
+<a id="opIdqueryByStatementPost"></a>
+
+> Code samples
+
+``` shell
+# You can also use wget
+curl -X POST https://testnets.tableland.network/api/v1/query \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json'
+```
+
+`POST /query`
+
+Returns the results of a SQL read query against the Tableland network
+
+> Body parameter
+
+``` json
+{
+  "statement": "select * from healthbot_80001_1",
+  "format": "objects",
+  "extract": false,
+  "unwrap": false
+}
+```
+
+<h3 id="query-the-network-(post)-parameters">
+Parameters
+</h3>
+
+| Name | In   | Type                  | Required | Description                                            |
+|------|------|-----------------------|----------|--------------------------------------------------------|
+| body | body | [Query](#schemaquery) | true     | A JSON containing the statement and additional options |
+
+> Example responses
+
+> 200 Response
+
+``` json
+{}
+```
+
+<h3 id="query-the-network-(post)-responses">
+Responses
+</h3>
+
+| Status | Meaning                                                            | Description                   | Schema |
+|--------|--------------------------------------------------------------------|-------------------------------|--------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)            | Successful operation          | Inline |
+| 400    | [Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)   | Invalid query/statement value | None   |
+| 404    | [Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)     | Row Not Found                 | None   |
+| 429    | [Too Many Requests](https://tools.ietf.org/html/rfc6585#section-4) | Too Many Requests             | None   |
+
+<h3 id="query-the-network-(post)-responseschema">
 Response Schema
 </h3>
 <aside class="success">
@@ -142,7 +207,7 @@ Get information about transaction progress
 
 > Code samples
 
-```shell
+``` shell
 # You can also use wget
 curl -X GET https://testnets.tableland.network/api/v1/receipt/{chainId}/{transactionHash} \
   -H 'Accept: application/json'
@@ -157,7 +222,7 @@ Parameters
 </h3>
 
 | Name            | In   | Type           | Required | Description                     |
-| --------------- | ---- | -------------- | -------- | ------------------------------- |
+|-----------------|------|----------------|----------|---------------------------------|
 | chainId         | path | integer(int32) | true     | The parent chain to target      |
 | transactionHash | path | string         | true     | The transaction hash to request |
 
@@ -165,10 +230,13 @@ Parameters
 
 > 200 Response
 
-```json
+``` json
 {
   "table_id": "1",
-  "table_ids": ["1", "2"],
+  "table_ids": [
+    "1",
+    "2"
+  ],
   "transaction_hash": "0x02f319429b8a7be1cbb492f0bfbf740d2472232a2edadde7df7c16c0b61aa78b",
   "block_number": 27055540,
   "chain_id": 80001,
@@ -182,7 +250,7 @@ Responses
 </h3>
 
 | Status | Meaning                                                            | Description                                         | Schema                                          |
-| ------ | ------------------------------------------------------------------ | --------------------------------------------------- | ----------------------------------------------- |
+|--------|--------------------------------------------------------------------|-----------------------------------------------------|-------------------------------------------------|
 | 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)            | successful operation                                | [TransactionReceipt](#schematransactionreceipt) |
 | 400    | [Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)   | Invalid chain identifier or transaction hash format | None                                            |
 | 404    | [Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)     | No transaction receipt found with the provided hash | None                                            |
@@ -205,7 +273,7 @@ Access to table information
 
 > Code samples
 
-```shell
+``` shell
 # You can also use wget
 curl -X GET https://testnets.tableland.network/api/v1/tables/{chainId}/{tableId} \
   -H 'Accept: application/json'
@@ -220,7 +288,7 @@ Parameters
 </h3>
 
 | Name    | In   | Type           | Required | Description                |
-| ------- | ---- | -------------- | -------- | -------------------------- |
+|---------|------|----------------|----------|----------------------------|
 | chainId | path | integer(int32) | true     | The parent chain to target |
 | tableId | path | string         | true     | Table identifier           |
 
@@ -228,7 +296,7 @@ Parameters
 
 > 200 Response
 
-```json
+``` json
 {
   "name": "healthbot_80001_1",
   "external_url": "https://testnets.tableland.network/api/v1/tables/80001/1",
@@ -244,10 +312,16 @@ Parameters
       {
         "name": "id",
         "type": "integer",
-        "constraints": ["NOT NULL", "PRIMARY KEY", "UNIQUE"]
+        "constraints": [
+          "NOT NULL",
+          "PRIMARY KEY",
+          "UNIQUE"
+        ]
       }
     ],
-    "table_constraints": ["PRIMARY KEY (id)"]
+    "table_constraints": [
+      "PRIMARY KEY (id)"
+    ]
   }
 }
 ```
@@ -257,7 +331,7 @@ Responses
 </h3>
 
 | Status | Meaning                                                                    | Description                       | Schema                |
-| ------ | -------------------------------------------------------------------------- | --------------------------------- | --------------------- |
+|--------|----------------------------------------------------------------------------|-----------------------------------|-----------------------|
 | 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)                    | successful operation              | [Table](#schematable) |
 | 400    | [Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)           | Invalid chain or table identifier | None                  |
 | 404    | [Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)             | Table Not Found                   | None                  |
@@ -277,7 +351,7 @@ health
 
 > Code samples
 
-```shell
+``` shell
 # You can also use wget
 curl -X GET https://testnets.tableland.network/api/v1/health
 ```
@@ -291,7 +365,7 @@ Responses
 </h3>
 
 | Status | Meaning                                                 | Description               | Schema |
-| ------ | ------------------------------------------------------- | ------------------------- | ------ |
+|--------|---------------------------------------------------------|---------------------------|--------|
 | 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | The validator is healthy. | None   |
 
 <aside class="success">
@@ -307,7 +381,7 @@ version
 
 > Code samples
 
-```shell
+``` shell
 # You can also use wget
 curl -X GET https://testnets.tableland.network/api/v1/version \
   -H 'Accept: application/json'
@@ -321,9 +395,8 @@ Returns version information about the validator daemon.
 
 > 200 Response
 
-```json
+``` json
 {
-  "version": 0,
   "git_commit": "79688910d4689dcc0991a0d8eb9d988200586d8f",
   "git_branch": "foo/experimentalfeature",
   "git_state": "dirty",
@@ -338,7 +411,7 @@ Responses
 </h3>
 
 | Status | Meaning                                                 | Description          | Schema                            |
-| ------ | ------------------------------------------------------- | -------------------- | --------------------------------- |
+|--------|---------------------------------------------------------|----------------------|-----------------------------------|
 | 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | successful operation | [VersionInfo](#schemaversioninfo) |
 
 <aside class="success">
@@ -355,7 +428,7 @@ Table
 <a id="schematable"></a> <a id="schema_Table"></a>
 <a id="tocStable"></a> <a id="tocstable"></a>
 
-```json
+``` json
 {
   "name": "healthbot_80001_1",
   "external_url": "https://testnets.tableland.network/api/v1/tables/80001/1",
@@ -371,10 +444,16 @@ Table
       {
         "name": "id",
         "type": "integer",
-        "constraints": ["NOT NULL", "PRIMARY KEY", "UNIQUE"]
+        "constraints": [
+          "NOT NULL",
+          "PRIMARY KEY",
+          "UNIQUE"
+        ]
       }
     ],
-    "table_constraints": ["PRIMARY KEY (id)"]
+    "table_constraints": [
+      "PRIMARY KEY (id)"
+    ]
   }
 }
 ```
@@ -382,7 +461,7 @@ Table
 ### Properties
 
 | Name           | Type       | Required | Restrictions | Description                       |
-| -------------- | ---------- | -------- | ------------ | --------------------------------- |
+|----------------|------------|----------|--------------|-----------------------------------|
 | name           | string     | false    | none         | none                              |
 | external_url   | string     | false    | none         | none                              |
 | animation_url  | string     | false    | none         | none                              |
@@ -395,37 +474,37 @@ Table
 oneOf
 
 | Name           | Type   | Required | Restrictions | Description |
-| -------------- | ------ | -------- | ------------ | ----------- |
-| »» _anonymous_ | string | false    | none         | none        |
+|----------------|--------|----------|--------------|-------------|
+| »» *anonymous* | string | false    | none         | none        |
 
 xor
 
 | Name           | Type   | Required | Restrictions | Description |
-| -------------- | ------ | -------- | ------------ | ----------- |
-| »» _anonymous_ | number | false    | none         | none        |
+|----------------|--------|----------|--------------|-------------|
+| »» *anonymous* | number | false    | none         | none        |
 
 xor
 
 | Name           | Type    | Required | Restrictions | Description |
-| -------------- | ------- | -------- | ------------ | ----------- |
-| »» _anonymous_ | integer | false    | none         | none        |
+|----------------|---------|----------|--------------|-------------|
+| »» *anonymous* | integer | false    | none         | none        |
 
 xor
 
 | Name           | Type    | Required | Restrictions | Description |
-| -------------- | ------- | -------- | ------------ | ----------- |
-| »» _anonymous_ | boolean | false    | none         | none        |
+|----------------|---------|----------|--------------|-------------|
+| »» *anonymous* | boolean | false    | none         | none        |
 
 xor
 
 | Name           | Type   | Required | Restrictions | Description |
-| -------------- | ------ | -------- | ------------ | ----------- |
-| »» _anonymous_ | object | false    | none         | none        |
+|----------------|--------|----------|--------------|-------------|
+| »» *anonymous* | object | false    | none         | none        |
 
 continued
 
 | Name   | Type                    | Required | Restrictions | Description |
-| ------ | ----------------------- | -------- | ------------ | ----------- |
+|--------|-------------------------|----------|--------------|-------------|
 | schema | [Schema](#schemaschema) | false    | none         | none        |
 
 <h2 id="tocS_TransactionReceipt">
@@ -437,10 +516,13 @@ TransactionReceipt
 <a id="schema_TransactionReceipt"></a>
 <a id="tocStransactionreceipt"></a> <a id="tocstransactionreceipt"></a>
 
-```json
+``` json
 {
   "table_id": "1",
-  "table_ids": ["1", "2"],
+  "table_ids": [
+    "1",
+    "2"
+  ],
   "transaction_hash": "0x02f319429b8a7be1cbb492f0bfbf740d2472232a2edadde7df7c16c0b61aa78b",
   "block_number": 27055540,
   "chain_id": 80001,
@@ -452,7 +534,7 @@ TransactionReceipt
 ### Properties
 
 | Name             | Type           | Required | Restrictions | Description              |
-| ---------------- | -------------- | -------- | ------------ | ------------------------ |
+|------------------|----------------|----------|--------------|--------------------------|
 | table_id         | string         | false    | none         | This field is deprecated |
 | table_ids        | \[string\]     | false    | none         | none                     |
 | transaction_hash | string         | false    | none         | none                     |
@@ -469,23 +551,29 @@ Schema
 <a id="schemaschema"></a> <a id="schema_Schema"></a>
 <a id="tocSschema"></a> <a id="tocsschema"></a>
 
-```json
+``` json
 {
   "columns": [
     {
       "name": "id",
       "type": "integer",
-      "constraints": ["NOT NULL", "PRIMARY KEY", "UNIQUE"]
+      "constraints": [
+        "NOT NULL",
+        "PRIMARY KEY",
+        "UNIQUE"
+      ]
     }
   ],
-  "table_constraints": ["PRIMARY KEY (id)"]
+  "table_constraints": [
+    "PRIMARY KEY (id)"
+  ]
 }
 ```
 
 ### Properties
 
 | Name              | Type                        | Required | Restrictions | Description |
-| ----------------- | --------------------------- | -------- | ------------ | ----------- |
+|-------------------|-----------------------------|----------|--------------|-------------|
 | columns           | \[[Column](#schemacolumn)\] | false    | none         | none        |
 | table_constraints | \[string\]                  | false    | none         | none        |
 
@@ -497,18 +585,22 @@ Column
 <a id="schemacolumn"></a> <a id="schema_Column"></a>
 <a id="tocScolumn"></a> <a id="tocscolumn"></a>
 
-```json
+``` json
 {
   "name": "id",
   "type": "integer",
-  "constraints": ["NOT NULL", "PRIMARY KEY", "UNIQUE"]
+  "constraints": [
+    "NOT NULL",
+    "PRIMARY KEY",
+    "UNIQUE"
+  ]
 }
 ```
 
 ### Properties
 
 | Name        | Type       | Required | Restrictions | Description |
-| ----------- | ---------- | -------- | ------------ | ----------- |
+|-------------|------------|----------|--------------|-------------|
 | name        | string     | false    | none         | none        |
 | type        | string     | false    | none         | none        |
 | constraints | \[string\] | false    | none         | none        |
@@ -521,9 +613,8 @@ VersionInfo
 <a id="schemaversioninfo"></a> <a id="schema_VersionInfo"></a>
 <a id="tocSversioninfo"></a> <a id="tocsversioninfo"></a>
 
-```json
+``` json
 {
-  "version": 0,
   "git_commit": "79688910d4689dcc0991a0d8eb9d988200586d8f",
   "git_branch": "foo/experimentalfeature",
   "git_state": "dirty",
@@ -535,12 +626,37 @@ VersionInfo
 
 ### Properties
 
-| Name           | Type           | Required | Restrictions | Description |
-| -------------- | -------------- | -------- | ------------ | ----------- |
-| version        | integer(int32) | false    | none         | none        |
-| git_commit     | string         | false    | none         | none        |
-| git_branch     | string         | false    | none         | none        |
-| git_state      | string         | false    | none         | none        |
-| git_summary    | string         | false    | none         | none        |
-| build_date     | string         | false    | none         | none        |
-| binary_version | string         | false    | none         | none        |
+| Name           | Type   | Required | Restrictions | Description |
+|----------------|--------|----------|--------------|-------------|
+| git_commit     | string | false    | none         | none        |
+| git_branch     | string | false    | none         | none        |
+| git_state      | string | false    | none         | none        |
+| git_summary    | string | false    | none         | none        |
+| build_date     | string | false    | none         | none        |
+| binary_version | string | false    | none         | none        |
+
+<h2 id="tocS_Query">
+Query
+</h2>
+<!-- backwards compatibility -->
+
+<a id="schemaquery"></a> <a id="schema_Query"></a>
+<a id="tocSquery"></a> <a id="tocsquery"></a>
+
+``` json
+{
+  "statement": "select * from healthbot_80001_1",
+  "format": "objects",
+  "extract": false,
+  "unwrap": false
+}
+```
+
+### Properties
+
+| Name      | Type    | Required | Restrictions | Description                                                                                                                                                                                       |
+|-----------|---------|----------|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| statement | string  | false    | none         | The SQL read query statement                                                                                                                                                                      |
+| format    | string  | false    | none         | The requested response format: \* `objects` - Returns the query results as a JSON array of JSON objects. \* `table` - Return the query results as a JSON object with columns and rows properties. |
+| extract   | boolean | false    | none         | Whether to extract the JSON object from the single property of the surrounding JSON object.                                                                                                       |
+| unwrap    | boolean | false    | none         | Whether to unwrap the returned JSON objects from their surrounding array.                                                                                                                         |

--- a/specs/validator/Specification.md
+++ b/specs/validator/Specification.md
@@ -1,28 +1,37 @@
 <!-- Generator: Widdershins v4.0.1 -->
 
-<h1 id="tableland-validator-openapi-3-0">Tableland Validator - OpenAPI 3.0 v1.0.1</h1>
+<h1 id="tableland-validator-openapi-3-0">Tableland Validator - OpenAPI 3.0 v1.1.0</h1>
 
 > Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
 
 In Tableland, Validators are the execution unit/actors of the protocol.
 They have the following responsibilities:
-
 - Listen to onchain events to materialize Tableland-compliant SQL queries in a database engine (currently, SQLite by default).
-- Serve read-queries (e.g: SELECT \* FROM foo_69_1) to the external world.
-- Serve state queries (e.g. list tables, get receipts, etc) to the external world.
+- Serve read-queries (e.g., SELECT * FROM foo_69_1) to the external world.
+- Serve state queries (e.g., list tables, get receipts, etc) to the external world.
 
 In the 1.0.0 release of the Tableland Validator API, we've switched to a design first approach!
 You can now help us improve the API whether it's by making changes to the definition itself or to the code.
 That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
 
+The API includes the following endpoints:
+- `/health`: Returns OK if the validator considers itself healthy.
+- `/version`: Returns version information about the validator daemon.
+- `/query`: Returns the results of a SQL read query against the Tableland
+network.
+- `/receipt/{chainId}/{transactionHash}`: Returns the status of a given
+transaction receipt by hash.
+- `/tables/{chainId}/{tableId}`: Returns information about a single table,
+including schema information.
+
 Base URLs:
 
-- <a href="https://testnets.tableland.network/api/v1">https://testnets.tableland.network/api/v1</a>
+* <a href="https://testnets.tableland.network/api/v1">https://testnets.tableland.network/api/v1</a>
 
-- <a href="http://localhost:8080/api/v1">http://localhost:8080/api/v1</a>
+* <a href="http://localhost:8080/api/v1">http://localhost:8080/api/v1</a>
 
 <a href="http://docs.tableland.xyz">Terms of service</a>
-Email: <a href="mailto:carson@textile.io">core devs</a>
+Email: <a href="mailto:carson@textile.io">core devs</a> 
 License: <a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0</a>
 
 <h1 id="tableland-validator-openapi-3-0-query">query</h1>
@@ -46,30 +55,29 @@ curl -X GET https://testnets.tableland.network/api/v1/query?statement=select%20%
 
 `GET /query`
 
-Returns the results of a SQL read query against the Tabeland network
+Returns the results of a SQL read query against the Tableland network
 
 <h3 id="query-the-network-parameters">Parameters</h3>
 
-| Name      | In    | Type    | Required | Description                                                                                 |
-| --------- | ----- | ------- | -------- | ------------------------------------------------------------------------------------------- |
-| statement | query | string  | true     | The SQL read query statement                                                                |
-| format    | query | string  | false    | The requested response format:                                                              |
-| extract   | query | boolean | false    | Whether to extract the JSON object from the single property of the surrounding JSON object. |
-| unwrap    | query | boolean | false    | Whether to unwrap the returned JSON objects from their surrounding array.                   |
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|statement|query|string|true|The SQL read query statement|
+|format|query|string|false|The requested response format:|
+|extract|query|boolean|false|Whether to extract the JSON object from the single property of the surrounding JSON object.|
+|unwrap|query|boolean|false|Whether to unwrap the returned JSON objects from their surrounding array.|
 
 #### Detailed descriptions
 
 **format**: The requested response format:
-
-- `objects` - Returns the query results as a JSON array of JSON objects.
-- `table` - Return the query results as a JSON object with columns and rows properties.
+ * `objects` - Returns the query results as a JSON array of JSON objects.
+ * `table` - Return the query results as a JSON object with columns and rows properties.
 
 #### Enumerated Values
 
-| Parameter | Value   |
-| --------- | ------- |
-| format    | objects |
-| format    | table   |
+|Parameter|Value|
+|---|---|
+|format|objects|
+|format|table|
 
 > Example responses
 
@@ -81,14 +89,72 @@ Returns the results of a SQL read query against the Tabeland network
 
 <h3 id="query-the-network-responses">Responses</h3>
 
-| Status | Meaning                                                            | Description                   | Schema |
-| ------ | ------------------------------------------------------------------ | ----------------------------- | ------ |
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)            | Successful operation          | Inline |
-| 400    | [Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)   | Invalid query/statement value | None   |
-| 404    | [Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)     | Row Not Found                 | None   |
-| 429    | [Too Many Requests](https://tools.ietf.org/html/rfc6585#section-4) | Too Many Requests             | None   |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Successful operation|Inline|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invalid query/statement value|None|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Row Not Found|None|
+|429|[Too Many Requests](https://tools.ietf.org/html/rfc6585#section-4)|Too Many Requests|None|
 
 <h3 id="query-the-network-responseschema">Response Schema</h3>
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## Query the network (POST)
+
+<a id="opIdqueryByStatementPost"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X POST https://testnets.tableland.network/api/v1/query \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json'
+
+```
+
+`POST /query`
+
+Returns the results of a SQL read query against the Tableland network
+
+> Body parameter
+
+```json
+{
+  "statement": "select * from healthbot_80001_1",
+  "format": "objects",
+  "extract": false,
+  "unwrap": false
+}
+```
+
+<h3 id="query-the-network-(post)-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[Query](#schemaquery)|true|A JSON containing the statement and additional options|
+
+> Example responses
+
+> 200 Response
+
+```json
+{}
+```
+
+<h3 id="query-the-network-(post)-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Successful operation|Inline|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invalid query/statement value|None|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Row Not Found|None|
+|429|[Too Many Requests](https://tools.ietf.org/html/rfc6585#section-4)|Too Many Requests|None|
+
+<h3 id="query-the-network-(post)-responseschema">Response Schema</h3>
 
 <aside class="success">
 This operation does not require authentication
@@ -119,10 +185,10 @@ Returns the status of a given transaction receipt by hash
 
 <h3 id="get-transaction-status-parameters">Parameters</h3>
 
-| Name            | In   | Type           | Required | Description                     |
-| --------------- | ---- | -------------- | -------- | ------------------------------- |
-| chainId         | path | integer(int32) | true     | The parent chain to target      |
-| transactionHash | path | string         | true     | The transaction hash to request |
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|chainId|path|integer(int32)|true|The parent chain to target|
+|transactionHash|path|string|true|The transaction hash to request|
 
 > Example responses
 
@@ -131,7 +197,10 @@ Returns the status of a given transaction receipt by hash
 ```json
 {
   "table_id": "1",
-  "table_ids": ["1", "2"],
+  "table_ids": [
+    "1",
+    "2"
+  ],
   "transaction_hash": "0x02f319429b8a7be1cbb492f0bfbf740d2472232a2edadde7df7c16c0b61aa78b",
   "block_number": 27055540,
   "chain_id": 80001,
@@ -142,12 +211,12 @@ Returns the status of a given transaction receipt by hash
 
 <h3 id="get-transaction-status-responses">Responses</h3>
 
-| Status | Meaning                                                            | Description                                         | Schema                                          |
-| ------ | ------------------------------------------------------------------ | --------------------------------------------------- | ----------------------------------------------- |
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)            | successful operation                                | [TransactionReceipt](#schematransactionreceipt) |
-| 400    | [Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)   | Invalid chain identifier or transaction hash format | None                                            |
-| 404    | [Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)     | No transaction receipt found with the provided hash | None                                            |
-| 429    | [Too Many Requests](https://tools.ietf.org/html/rfc6585#section-4) | Too Many Requests                                   | None                                            |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|successful operation|[TransactionReceipt](#schematransactionreceipt)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invalid chain identifier or transaction hash format|None|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|No transaction receipt found with the provided hash|None|
+|429|[Too Many Requests](https://tools.ietf.org/html/rfc6585#section-4)|Too Many Requests|None|
 
 <aside class="success">
 This operation does not require authentication
@@ -178,10 +247,10 @@ Returns information about a single table, including schema information
 
 <h3 id="get-table-information-parameters">Parameters</h3>
 
-| Name    | In   | Type           | Required | Description                |
-| ------- | ---- | -------------- | -------- | -------------------------- |
-| chainId | path | integer(int32) | true     | The parent chain to target |
-| tableId | path | string         | true     | Table identifier           |
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|chainId|path|integer(int32)|true|The parent chain to target|
+|tableId|path|string|true|Table identifier|
 
 > Example responses
 
@@ -203,23 +272,29 @@ Returns information about a single table, including schema information
       {
         "name": "id",
         "type": "integer",
-        "constraints": ["NOT NULL", "PRIMARY KEY", "UNIQUE"]
+        "constraints": [
+          "NOT NULL",
+          "PRIMARY KEY",
+          "UNIQUE"
+        ]
       }
     ],
-    "table_constraints": ["PRIMARY KEY (id)"]
+    "table_constraints": [
+      "PRIMARY KEY (id)"
+    ]
   }
 }
 ```
 
 <h3 id="get-table-information-responses">Responses</h3>
 
-| Status | Meaning                                                                    | Description                       | Schema                |
-| ------ | -------------------------------------------------------------------------- | --------------------------------- | --------------------- |
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)                    | successful operation              | [Table](#schematable) |
-| 400    | [Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)           | Invalid chain or table identifier | None                  |
-| 404    | [Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)             | Table Not Found                   | None                  |
-| 429    | [Too Many Requests](https://tools.ietf.org/html/rfc6585#section-4)         | Too Many Requests                 | None                  |
-| 500    | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | Internal Server Error             | None                  |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|successful operation|[Table](#schematable)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invalid chain or table identifier|None|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Table Not Found|None|
+|429|[Too Many Requests](https://tools.ietf.org/html/rfc6585#section-4)|Too Many Requests|None|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|None|
 
 <aside class="success">
 This operation does not require authentication
@@ -245,9 +320,9 @@ Returns OK if the validator considers itself healthy.
 
 <h3 id="get-health-status-responses">Responses</h3>
 
-| Status | Meaning                                                 | Description               | Schema |
-| ------ | ------------------------------------------------------- | ------------------------- | ------ |
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | The validator is healthy. | None   |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|The validator is healthy.|None|
 
 <aside class="success">
 This operation does not require authentication
@@ -278,7 +353,6 @@ Returns version information about the validator daemon.
 
 ```json
 {
-  "version": 0,
   "git_commit": "79688910d4689dcc0991a0d8eb9d988200586d8f",
   "git_branch": "foo/experimentalfeature",
   "git_state": "dirty",
@@ -290,9 +364,9 @@ Returns version information about the validator daemon.
 
 <h3 id="get-version-information-responses">Responses</h3>
 
-| Status | Meaning                                                 | Description          | Schema                            |
-| ------ | ------------------------------------------------------- | -------------------- | --------------------------------- |
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | successful operation | [VersionInfo](#schemaversioninfo) |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|successful operation|[VersionInfo](#schemaversioninfo)|
 
 <aside class="success">
 This operation does not require authentication
@@ -323,62 +397,69 @@ This operation does not require authentication
       {
         "name": "id",
         "type": "integer",
-        "constraints": ["NOT NULL", "PRIMARY KEY", "UNIQUE"]
+        "constraints": [
+          "NOT NULL",
+          "PRIMARY KEY",
+          "UNIQUE"
+        ]
       }
     ],
-    "table_constraints": ["PRIMARY KEY (id)"]
+    "table_constraints": [
+      "PRIMARY KEY (id)"
+    ]
   }
 }
+
 ```
 
 ### Properties
 
-| Name           | Type     | Required | Restrictions | Description                       |
-| -------------- | -------- | -------- | ------------ | --------------------------------- |
-| name           | string   | false    | none         | none                              |
-| external_url   | string   | false    | none         | none                              |
-| animation_url  | string   | false    | none         | none                              |
-| image          | string   | false    | none         | none                              |
-| attributes     | [object] | false    | none         | none                              |
-| » display_type | string   | false    | none         | The display type for marketplaces |
-| » trait_type   | string   | false    | none         | The trait type for marketplaces   |
-| » value        | object   | false    | none         | The value of the property         |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|false|none|none|
+|external_url|string|false|none|none|
+|animation_url|string|false|none|none|
+|image|string|false|none|none|
+|attributes|[object]|false|none|none|
+|» display_type|string|false|none|The display type for marketplaces|
+|» trait_type|string|false|none|The trait type for marketplaces|
+|» value|object|false|none|The value of the property|
 
 oneOf
 
-| Name           | Type   | Required | Restrictions | Description |
-| -------------- | ------ | -------- | ------------ | ----------- |
-| »» _anonymous_ | string | false    | none         | none        |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|»» *anonymous*|string|false|none|none|
 
 xor
 
-| Name           | Type   | Required | Restrictions | Description |
-| -------------- | ------ | -------- | ------------ | ----------- |
-| »» _anonymous_ | number | false    | none         | none        |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|»» *anonymous*|number|false|none|none|
 
 xor
 
-| Name           | Type    | Required | Restrictions | Description |
-| -------------- | ------- | -------- | ------------ | ----------- |
-| »» _anonymous_ | integer | false    | none         | none        |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|»» *anonymous*|integer|false|none|none|
 
 xor
 
-| Name           | Type    | Required | Restrictions | Description |
-| -------------- | ------- | -------- | ------------ | ----------- |
-| »» _anonymous_ | boolean | false    | none         | none        |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|»» *anonymous*|boolean|false|none|none|
 
 xor
 
-| Name           | Type   | Required | Restrictions | Description |
-| -------------- | ------ | -------- | ------------ | ----------- |
-| »» _anonymous_ | object | false    | none         | none        |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|»» *anonymous*|object|false|none|none|
 
 continued
 
-| Name   | Type                    | Required | Restrictions | Description |
-| ------ | ----------------------- | -------- | ------------ | ----------- |
-| schema | [Schema](#schemaschema) | false    | none         | none        |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|schema|[Schema](#schemaschema)|false|none|none|
 
 <h2 id="tocS_TransactionReceipt">TransactionReceipt</h2>
 <!-- backwards compatibility -->
@@ -390,26 +471,30 @@ continued
 ```json
 {
   "table_id": "1",
-  "table_ids": ["1", "2"],
+  "table_ids": [
+    "1",
+    "2"
+  ],
   "transaction_hash": "0x02f319429b8a7be1cbb492f0bfbf740d2472232a2edadde7df7c16c0b61aa78b",
   "block_number": 27055540,
   "chain_id": 80001,
   "error": "The query statement is invalid",
   "error_event_idx": 1
 }
+
 ```
 
 ### Properties
 
-| Name             | Type           | Required | Restrictions | Description              |
-| ---------------- | -------------- | -------- | ------------ | ------------------------ |
-| table_id         | string         | false    | none         | This field is deprecated |
-| table_ids        | [string]       | false    | none         | none                     |
-| transaction_hash | string         | false    | none         | none                     |
-| block_number     | integer(int64) | false    | none         | none                     |
-| chain_id         | integer(int32) | false    | none         | none                     |
-| error            | string         | false    | none         | none                     |
-| error_event_idx  | integer(int32) | false    | none         | none                     |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|table_id|string|false|none|This field is deprecated|
+|table_ids|[string]|false|none|none|
+|transaction_hash|string|false|none|none|
+|block_number|integer(int64)|false|none|none|
+|chain_id|integer(int32)|false|none|none|
+|error|string|false|none|none|
+|error_event_idx|integer(int32)|false|none|none|
 
 <h2 id="tocS_Schema">Schema</h2>
 <!-- backwards compatibility -->
@@ -424,19 +509,26 @@ continued
     {
       "name": "id",
       "type": "integer",
-      "constraints": ["NOT NULL", "PRIMARY KEY", "UNIQUE"]
+      "constraints": [
+        "NOT NULL",
+        "PRIMARY KEY",
+        "UNIQUE"
+      ]
     }
   ],
-  "table_constraints": ["PRIMARY KEY (id)"]
+  "table_constraints": [
+    "PRIMARY KEY (id)"
+  ]
 }
+
 ```
 
 ### Properties
 
-| Name              | Type                      | Required | Restrictions | Description |
-| ----------------- | ------------------------- | -------- | ------------ | ----------- |
-| columns           | [[Column](#schemacolumn)] | false    | none         | none        |
-| table_constraints | [string]                  | false    | none         | none        |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|columns|[[Column](#schemacolumn)]|false|none|none|
+|table_constraints|[string]|false|none|none|
 
 <h2 id="tocS_Column">Column</h2>
 <!-- backwards compatibility -->
@@ -449,17 +541,22 @@ continued
 {
   "name": "id",
   "type": "integer",
-  "constraints": ["NOT NULL", "PRIMARY KEY", "UNIQUE"]
+  "constraints": [
+    "NOT NULL",
+    "PRIMARY KEY",
+    "UNIQUE"
+  ]
 }
+
 ```
 
 ### Properties
 
-| Name        | Type     | Required | Restrictions | Description |
-| ----------- | -------- | -------- | ------------ | ----------- |
-| name        | string   | false    | none         | none        |
-| type        | string   | false    | none         | none        |
-| constraints | [string] | false    | none         | none        |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|false|none|none|
+|type|string|false|none|none|
+|constraints|[string]|false|none|none|
 
 <h2 id="tocS_VersionInfo">VersionInfo</h2>
 <!-- backwards compatibility -->
@@ -470,7 +567,6 @@ continued
 
 ```json
 {
-  "version": 0,
   "git_commit": "79688910d4689dcc0991a0d8eb9d988200586d8f",
   "git_branch": "foo/experimentalfeature",
   "git_state": "dirty",
@@ -478,16 +574,43 @@ continued
   "build_date": "2022-11-29T16:28:04Z",
   "binary_version": "v1.0.1"
 }
+
 ```
 
 ### Properties
 
-| Name           | Type           | Required | Restrictions | Description |
-| -------------- | -------------- | -------- | ------------ | ----------- |
-| version        | integer(int32) | false    | none         | none        |
-| git_commit     | string         | false    | none         | none        |
-| git_branch     | string         | false    | none         | none        |
-| git_state      | string         | false    | none         | none        |
-| git_summary    | string         | false    | none         | none        |
-| build_date     | string         | false    | none         | none        |
-| binary_version | string         | false    | none         | none        |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|git_commit|string|false|none|none|
+|git_branch|string|false|none|none|
+|git_state|string|false|none|none|
+|git_summary|string|false|none|none|
+|build_date|string|false|none|none|
+|binary_version|string|false|none|none|
+
+<h2 id="tocS_Query">Query</h2>
+<!-- backwards compatibility -->
+<a id="schemaquery"></a>
+<a id="schema_Query"></a>
+<a id="tocSquery"></a>
+<a id="tocsquery"></a>
+
+```json
+{
+  "statement": "select * from healthbot_80001_1",
+  "format": "objects",
+  "extract": false,
+  "unwrap": false
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|statement|string|false|none|The SQL read query statement|
+|format|string|false|none|The requested response format: * `objects` - Returns the query results as a JSON array of JSON objects. * `table` - Return the query results as a JSON object with columns and rows properties.|
+|extract|boolean|false|none|Whether to extract the JSON object from the single property of the surrounding JSON object.|
+|unwrap|boolean|false|none|Whether to unwrap the returned JSON objects from their surrounding array.|
+

--- a/specs/validator/tableland-openapi-spec.yaml
+++ b/specs/validator/tableland-openapi-spec.yaml
@@ -29,7 +29,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-  version: 1.0.1
+  version: 1.1.0
 externalDocs:
   description: Tableland docs
   url: http://docs.tableland.xyz
@@ -82,7 +82,7 @@ paths:
       tags:
         - query
       summary: Query the network
-      description: Returns the results of a SQL read query against the Tabeland network
+      description: Returns the results of a SQL read query against the Tableland network
       operationId: queryByStatement
       parameters:
         - name: statement
@@ -119,6 +119,32 @@ paths:
           schema:
             type: boolean
             default: false
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+        "400":
+          description: Invalid query/statement value
+        "404":
+          description: Row Not Found
+        "429":
+          description: Too Many Requests
+    post:
+      tags:
+        - query
+      summary: Query the network (POST)
+      description: Returns the results of a SQL read query against the Tableland network
+      operationId: queryByStatementPost
+      requestBody:
+        description: A JSON containing the statement and additional options
+        required: true
+        content: 
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/Query'
       responses:
         "200":
           description: Successful operation
@@ -330,3 +356,25 @@ components:
         binary_version:
           type: string
           example: "v1.0.1"
+    Query:
+      type: object
+      properties:
+        statement:
+          description: The SQL read query statement
+          type: string
+          example: select * from healthbot_80001_1
+        format:
+          description: >
+            The requested response format:
+            * `objects` - Returns the query results as a JSON array of JSON objects.
+            * `table` - Return the query results as a JSON object with columns and rows properties.
+          type: string
+          example: objects
+        extract:
+          description: Whether to extract the JSON object from the single property of the surrounding JSON object.
+          type: boolean
+          example: false
+        unwrap:
+          description: Whether to unwrap the returned JSON objects from their surrounding array.
+          type: boolean
+          example: false


### PR DESCRIPTION
Adds support for `POST /query` to the spec. The body request has the following JSON schema:

```json
{
  "statement" : "select * from foo",
  "format": "objects",
  "extract": false,
  "unwrap": false
}
```